### PR TITLE
Filter alignments by min id

### DIFF
--- a/src/align/include/computeAlignments.hpp
+++ b/src/align/include/computeAlignments.hpp
@@ -434,6 +434,7 @@ namespace align
             currentRecord.strand != skch::strnd::FWD,
             refId, refRegion, refSize, currentRecord.rStartPos, refLen,
             param.wflambda_segment_length,
+            param.min_identity,
             param.wflambda_min_wavefront_length,
             param.wflambda_max_distance_threshold);
 

--- a/src/common/wflign/src/main.cpp
+++ b/src/common/wflign/src/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
     args::PositionalList<std::string> query_sequence_files(parser, "queries", "query sequences");
     args::ValueFlag<std::string> query_sequence_file_list(parser, "queries", "alignment query file list", {'Q', "query-file-list"});
     args::ValueFlag<uint64_t> p_segment_length(parser, "N", "segment length for aligning [default: 1000]", {'s', "segment-length"});
-    args::ValueFlag<float> min_pct_identity(parser, "%", "only emit alignments above this percent identity (edlib only) [default: 0]", {'I', "min-pct-id"});
+    args::ValueFlag<float> min_pct_identity(parser, "%", "only emit alignments above this percent identity [default: 0]", {'I', "min-pct-id"});
     args::ValueFlag<int> wf_min(parser, "N", "WFlambda_min: minimum length of a wavefront to trigger reduction [default: 100]", {'l', "wf-min"});
     args::ValueFlag<int> wf_diff(parser, "N", "WFlambda_diff: maximum distance in bp that a wavefront may be behind the best wavefront to not be reduced [default: 100000]", {'d', "wf-diff"});
     args::Flag exact_wflign(parser, "N", "compute the exact WFA for wflign, don't use adaptive wavefront reduction", {'e', "exact-wflign"});
@@ -121,6 +121,7 @@ int main(int argc, char** argv) {
                                     revcomp,
                                     tname, tseq.c_str(), tseq.size(), 0, tseq.size(),
                                     segment_length,
+                                    min_identity,
                                     min_wavefront_length,
                                     max_distance_threshold);
                             }

--- a/src/common/wflign/src/wflign_wfa.hpp
+++ b/src/common/wflign/src/wflign_wfa.hpp
@@ -157,6 +157,7 @@ void wflign_affine_wavefront(
     const uint64_t& target_offset,
     const uint64_t& target_length,
     const uint64_t& segment_length,
+    const float& min_identity,
     const int& wflambda_min_wavefront_length, // with these set at 0 we do exact WFA for wflambda
     const int& wflambda_max_distance_threshold);
     //const int& wfa_min_wavefront_length, // with these set at 0 we do exact WFA for WFA itself
@@ -198,6 +199,7 @@ void write_merged_alignment(
     const uint64_t& target_total_length,
     const uint64_t& target_offset,
     const uint64_t& target_length,
+    const float& min_identity,
     const bool& with_endline = true);
 
 void write_alignment(
@@ -212,6 +214,7 @@ void write_alignment(
     const uint64_t& target_total_length,
     const uint64_t& target_offset,
     const uint64_t& target_length,
+    const float& min_identity,
     const bool& with_endline = true);
 
 

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -277,7 +277,7 @@ namespace skch
                                  int64_t q_l = (int64_t)e.queryEndPos - (int64_t)e.queryStartPos;
                                  int64_t r_l = (int64_t)e.refEndPos + 1 - (int64_t)e.refStartPos;
                                  uint64_t delta = std::abs(r_l - q_l);
-                                 float len_id_bound = 100 * (1.0 - (float)delta/(float)q_l);
+                                 float len_id_bound = (1.0 - (float)delta/(float)q_l);
                                  return len_id_bound < param.percentageIdentity;
                              }),
               readMappings.end());
@@ -621,8 +621,8 @@ namespace skch
             //Compute lower bound to mash distance within 90% confidence interval
             float mash_dist_lower_bound = Stat::md_lower_bound(mash_dist, Q.sketchSize, param.kmerSize, skch::fixed::confidence_interval);
 
-            float nucIdentity = 100 * (1 - mash_dist);
-            float nucIdentityUpperBound = 100 * (1 - mash_dist_lower_bound);
+            float nucIdentity = (1 - mash_dist);
+            float nucIdentityUpperBound = (1 - mash_dist_lower_bound);
 
             //Report the alignment if it passes our identity threshold and,
             // if we are in all-vs-all mode, it isn't a self-mapping,
@@ -961,7 +961,7 @@ namespace skch
         {
           assert(e.refSeqId < this->refSketch.metadata.size());
 
-          float fakeMapQ = std::round(-10.0 * std::log10(1-(e.nucIdentity/100)));
+          float fakeMapQ = std::round(-10.0 * std::log10(1-(e.nucIdentity)));
           if (std::isinf(fakeMapQ)) fakeMapQ = 255;
 
           outstrm  << (param.filterMode == filter::ONETOONE ? qmetadata[e.querySeqId].name : queryName)
@@ -976,7 +976,7 @@ namespace skch
                    << "\t" << e.approxMatches
                    << "\t" << e.blockLength
                    << "\t" << fakeMapQ
-                   << "\t" << "id:f:" << e.nucIdentity;
+                   << "\t" << "id:f:" << e.nucIdentity * 100.0;
               //<< "\t" << "nu:f:" << e.nucIdentityUpperBound;
 
 #ifdef DEBUG

--- a/src/map/include/map_stats.hpp
+++ b/src/map/include/map_stats.hpp
@@ -114,13 +114,13 @@ namespace skch
      * @brief                 Estimate minimum number of shared sketches to achieve the desired identity
      * @param[in] s           sketch size
      * @param[in] k           kmer size
-     * @param[in] identity    percentage identity [0-100]
+     * @param[in] identity    percentage identity [0-1]
      * @return                minimum count of hits
      */
     inline int estimateMinimumHits(int s, int k, float perc_identity)
     {
       //Compute the estimate
-      float mash_dist = 1.0 - perc_identity/100.0;
+      float mash_dist = 1.0 - perc_identity;
       float jaccard = md2j(mash_dist, k);
 
       //function to convert jaccard to min hits
@@ -136,7 +136,7 @@ namespace skch
      *                        Upper bound is computed using the 90% confidence interval
      * @param[in] s           sketch size
      * @param[in] k           kmer size
-     * @param[in] identity    percentage identity [0-100]
+     * @param[in] identity    percentage identity [0-1]
      * @return                count of min. shared minimizers
      */
     inline int estimateMinimumHitsRelaxed(int s, int k, float perc_identity)
@@ -154,7 +154,7 @@ namespace skch
         float d_lower = md_lower_bound(d, s, k, skch::fixed::confidence_interval);
 
         //Upper bound identity
-        float id_upper = 100.0 * (1.0 - d_lower);
+        float id_upper = 1.0 - d_lower;
 
         //Check if it satisfies the criteria
         if(id_upper >= perc_identity)

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -39,7 +39,8 @@ void parse_args(int argc,
     args::ValueFlag<int> kmer_size(parser, "N", "kmer size <= 16 [default: 16]", {'k', "kmer"});
     args::Flag no_split(parser, "no-split", "disable splitting of input sequences during mapping [enabled by default]", {'N',"no-split"});
     args::ValueFlag<float> map_pct_identity(parser, "%", "use this percent identity in the mashmap step [default: 95]", {'p', "map-pct-id"});
-    args::Flag keep_low_pct_identity(parser, "K", "keep mappings with estimated identity below our threshold", {'K', "keep-low-pct-id"});
+    args::Flag keep_low_map_pct_identity(parser, "K", "keep mappings with estimated identity below --map-pct-id=%", {'K', "keep-low-map-id"});
+    args::Flag keep_low_align_pct_identity(parser, "A", "keep alignments with gap-compressed identity below --map-pct-id=%", {'O', "keep-low-align-id"});
     args::ValueFlag<std::string> map_filter_mode(parser, "MODE", "filter mode for map step, either 'map', 'one-to-one', or 'none' [default: map]", {'f', "map-filter-mode"});
     args::ValueFlag<int> map_secondaries(parser, "N", "number of secondary mappings to retain in 'map' filter mode (total number of mappings is this + 1) [default: 0]", {'n', "n-secondary"});
     args::ValueFlag<int> map_short_secondaries(parser, "N", "number of secondary mappings to retain for sequences shorter than segment length [default: 0]", {'S', "n-short-secondary"});
@@ -49,7 +50,6 @@ void parse_args(int argc,
     args::Flag no_merge(parser, "no-merge", "don't merge consecutive segment-level mappings", {'M', "no-merge"});
     // align parameters
     args::ValueFlag<std::string> align_input_paf(parser, "FILE", "derive precise alignments for this input PAF", {'i', "input-paf"});
-    //args::ValueFlag<float> align_pct_identity(parser, "%", "filter WFA alignments from wflign with less than this identity [default: 70]", {'a', "align-pct-id"});
     args::ValueFlag<int> wflambda_segment_length(parser, "N", "wflambda segment length: size (in bp) of segment mapped in hierarchical WFA problem [default: 200]", {'W', "wflamda-segment"});
     args::ValueFlag<int> wflambda_min_wavefront_length(parser, "N", "minimum wavefront length (width) to trigger reduction [default: 100]", {'A', "wflamda-min"});
     args::ValueFlag<int> wflambda_max_distance_threshold(parser, "N", "maximum distance that a wavefront may be behind the best wavefront [default: 100000]", {'D', "wflambda-diff"});
@@ -153,13 +153,17 @@ void parse_args(int argc,
         map_parameters.percentageIdentity = 95;
     }
 
-    if (keep_low_pct_identity) {
+    if (keep_low_map_pct_identity) {
         map_parameters.keep_low_pct_id = true;
     } else {
         map_parameters.keep_low_pct_id = false;
     }
 
-    align_parameters.min_identity = 0; // now unused
+    if (keep_low_map_pct_identity) {
+        align_parameters.min_identity = 0; // now unused
+    } else {
+        align_parameters.min_identity = map_parameters.percentageIdentity;
+    }
 
     if (wflambda_segment_length) {
         align_parameters.wflambda_segment_length = args::get(wflambda_segment_length);

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -144,13 +144,13 @@ void parse_args(int argc,
     }
 
     if (map_pct_identity) {
-        map_parameters.percentageIdentity = args::get(map_pct_identity);
-        if (map_parameters.percentageIdentity < 70) {
+        map_parameters.percentageIdentity = (float)args::get(map_pct_identity)/100.0;
+        if (map_parameters.percentageIdentity < 0.7) {
             std::cerr << "[wfmash] ERROR, skch::parseandSave, minimum nucleotide identity requirement should be >= 70\%" << std::endl;
             exit(1);
         }
     } else {
-        map_parameters.percentageIdentity = 95;
+        map_parameters.percentageIdentity = 0.95;
     }
 
     if (keep_low_map_pct_identity) {

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -159,10 +159,10 @@ void parse_args(int argc,
         map_parameters.keep_low_pct_id = false;
     }
 
-    if (keep_low_map_pct_identity) {
+    if (keep_low_align_pct_identity) {
         align_parameters.min_identity = 0; // now unused
     } else {
-        align_parameters.min_identity = map_parameters.percentageIdentity;
+        align_parameters.min_identity = map_parameters.percentageIdentity / 100.0;
     }
 
     if (wflambda_segment_length) {


### PR DESCRIPTION
Alignments with gap compressed identity lower than our mapping threshold tend to be problematic. This filters them.