### PR TITLE
use edlib distance to guide our wflign wavefront

### DIFF
--- a/src/common/wflign/deps/wflambda/wflambda/gap_affine/affine_wavefront_extend.cpp
+++ b/src/common/wflign/deps/wflambda/wflambda/gap_affine/affine_wavefront_extend.cpp
@@ -211,7 +211,9 @@ void affine_wavefronts_extend_mwavefront_compute(
       ++(offsets[k]);
 //#define AFFINE_LAMBDA_WAVEFRONT_SHOW
 #ifdef AFFINE_LAMBDA_WAVEFRONT_SHOW
-      std::cerr << v-1 << "\t" << h-1 << "\t" << score << "\t" << "aligned" << std::endl;
+      if (v-1 >= 0 && h-1 >= 0 && v-1 < pattern_length && h-1 < pattern_length) {
+          std::cerr << v-1 << "\t" << h-1 << "\t" << score << "\t" << "aligned" << std::endl;
+      }
 #endif
     }
 #ifdef AFFINE_LAMBDA_WAVEFRONT_SHOW

--- a/src/common/wflign/src/wflign_wfa.hpp
+++ b/src/common/wflign/src/wflign_wfa.hpp
@@ -13,6 +13,7 @@
 #include "wflambda/gap_affine/affine_wavefront_align.hpp"
 #include "wflambda/gap_affine/affine_wavefront_backtrace.hpp"
 #include "dna.hpp"
+#include "edlib.h"
 #include "rkmh.hpp"
 
 //#define WFLIGN_DEBUG true // for debugging messages
@@ -28,7 +29,7 @@ struct alignment_t {
     int target_length = 0;
     bool ok = false;
     int score = std::numeric_limits<int>::max();
-    double mash_dist = 1;
+    double dist = 1;
     wfa::edit_cigar_t edit_cigar;
     void trim_front(int query_trim) {
         // this kills the alignment
@@ -161,18 +162,14 @@ void wflign_affine_wavefront(
     const float& min_identity,
     const int& wflambda_min_wavefront_length, // with these set at 0 we do exact WFA for wflambda
     const int& wflambda_max_distance_threshold);
-    //const int& wfa_min_wavefront_length, // with these set at 0 we do exact WFA for WFA itself
-    //const int& wfa_max_distance_threshold);
 
 bool do_alignment(
     const std::string& query_name,
     const char* query,
-    std::vector<rkmh::hash_t>*& query_sketches,
     const uint64_t& query_length,
     const uint64_t& j,
     const std::string& target_name,
     const char* target,
-    std::vector<rkmh::hash_t>*& target_sketches,
     const uint64_t& target_length,
     const uint64_t& i,
     const uint64_t& segment_length,

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -50,7 +50,7 @@ void parse_args(int argc,
     args::Flag no_merge(parser, "no-merge", "don't merge consecutive segment-level mappings", {'M', "no-merge"});
     // align parameters
     args::ValueFlag<std::string> align_input_paf(parser, "FILE", "derive precise alignments for this input PAF", {'i', "input-paf"});
-    args::ValueFlag<int> wflambda_segment_length(parser, "N", "wflambda segment length: size (in bp) of segment mapped in hierarchical WFA problem [default: 200]", {'W', "wflamda-segment"});
+    args::ValueFlag<int> wflambda_segment_length(parser, "N", "wflambda segment length: size (in bp) of segment mapped in hierarchical WFA problem [default: 500]", {'W', "wflamda-segment"});
     args::ValueFlag<int> wflambda_min_wavefront_length(parser, "N", "minimum wavefront length (width) to trigger reduction [default: 100]", {'A', "wflamda-min"});
     args::ValueFlag<int> wflambda_max_distance_threshold(parser, "N", "maximum distance that a wavefront may be behind the best wavefront [default: 100000]", {'D', "wflambda-diff"});
     args::Flag exact_wflambda(parser, "N", "compute the exact wflambda, don't use adaptive wavefront reduction", {'E', "exact-wflambda"});
@@ -178,7 +178,7 @@ void parse_args(int argc,
     if (wflambda_segment_length) {
         align_parameters.wflambda_segment_length = args::get(wflambda_segment_length);
     } else {
-        align_parameters.wflambda_segment_length = 200;
+        align_parameters.wflambda_segment_length = 500;
     }
 
     if (wflambda_min_wavefront_length) {


### PR DESCRIPTION
Before aligning each segment pair, we were checking if the distance was acceptable using mash distance. This added some overhead to compute. It is also problematically approximate, and added a new free parameter (the kmer length used) to the algorithm.

Instead, we can use edlib to get the edit distance. If this is acceptable, we attempt a bounded WFA alignment of the segment pair. Due to being simpler, this is significantly faster. It also appears to improve the sensitivity of the alignment.

The inception of edlib in wflign lets us work with larger wflambda segments. On my test system, I find that setting -W to 500 provides excellent runtime, so this has been set as the default for wfmash.