### PR TITLE
expose mashmap pvalue and confidence interval

### DIFF
--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -536,7 +536,7 @@ namespace skch
             }
           }
 
-          int minimumHits = Stat::estimateMinimumHitsRelaxed(Q.sketchSize, param.kmerSize, param.percentageIdentity);
+          int minimumHits = Stat::estimateMinimumHitsRelaxed(Q.sketchSize, param.kmerSize, param.percentageIdentity, param.confidence_interval);
 
           this->computeL1CandidateRegions(Q, seedHitsL1, minimumHits, l1Mappings);
 
@@ -621,7 +621,7 @@ namespace skch
             float mash_dist = Stat::j2md(1.0 * l2.sharedSketchSize/Q.sketchSize, param.kmerSize);
 
             //Compute lower bound to mash distance within 90% confidence interval
-            float mash_dist_lower_bound = Stat::md_lower_bound(mash_dist, Q.sketchSize, param.kmerSize, skch::fixed::confidence_interval);
+            float mash_dist_lower_bound = Stat::md_lower_bound(mash_dist, Q.sketchSize, param.kmerSize, param.confidence_interval);
 
             float nucIdentity = (1 - mash_dist);
             float nucIdentityUpperBound = (1 - mash_dist_lower_bound);

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -17,7 +17,7 @@ namespace skch
 struct Parameters
 {
     int kmerSize;                                     //kmer size for sketching
-    int windowSize;                                   //window size used for sketching 
+    int windowSize;                                   //window size used for sketching
     int segLength;                                    //For split mapping case, this represents the fragment length
                                                       //for noSplit, it represents minimum read length to multimap
     int block_length_min;                             // minimum (potentially merged) block to keep if we aren't split
@@ -32,11 +32,14 @@ struct Parameters
     std::vector<std::string> querySequences;          //query sequence(s)
     std::string outFileName;                          //output file name
     bool split;                                       //Split read mapping (done if this is true)
-    bool skip_self;                                   // skip self mappings
-    bool skip_prefix;                                 // skip mappings to sequences with the same prefix
-    char prefix_delim;                                // the prefix delimiter
+    bool skip_self;                                   //skip self mappings
+    bool skip_prefix;                                 //skip mappings to sequences with the same prefix
+    char prefix_delim;                                //the prefix delimiter
     bool mergeMappings;                               //if we should merge consecutive segment mappings
     bool keep_low_pct_id;                             //true if we should keep mappings whose estimated identity < percentageIdentity
+
+    float pval_cutoff;                                //p-value cutoff for determining window size
+    float confidence_interval;                        //Confidence interval to relax jaccard cutoff for mapping (0-1)
 };
 
 
@@ -46,11 +49,7 @@ struct Parameters
 namespace fixed
 {
 
-float pval_cutoff = 1e-03;                        //p-value cutoff for determining window size
-
-float confidence_interval = 0.75;                 //Confidence interval to relax jaccard cutoff for mapping (0-1)
-
-float filter_score_best_range = .99;              //mapping score above a certain fraction of best score is 
+float filter_score_best_range = .99;              //mapping score above a certain fraction of best score is
 //considered good by filtering algorithm
 
 int max_best_mappings_per_position = 25;          //At a particular position, if algorithm finds more than a certain best 

--- a/src/map/include/parseCmdArgs.hpp
+++ b/src/map/include/parseCmdArgs.hpp
@@ -322,10 +322,11 @@ sequences shorter than segment length will be ignored", ArgvParser::OptionRequir
      */
 
     //Compute optimal window size
-    parameters.windowSize = skch::Stat::recommendedWindowSize(skch::fixed::pval_cutoff,
-        parameters.kmerSize, parameters.alphabetSize,
-        parameters.percentageIdentity,
-        parameters.segLength, parameters.referenceSize);
+    parameters.windowSize = skch::Stat::recommendedWindowSize(
+            parameters.pval_cutoff, parameters.confidence_interval,
+            parameters.kmerSize, parameters.alphabetSize,
+            parameters.percentageIdentity,
+            parameters.segLength, parameters.referenceSize);
 
     if(cmd.foundOption("output"))
     {

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -48,6 +48,10 @@ void parse_args(int argc,
     args::ValueFlag<char> skip_prefix(parser, "C", "skip mappings when the query and target have the same prefix before the given character C", {'Y', "skip-prefix"});
     args::Flag approx_mapping(parser, "approx-map", "skip base-level alignment, producing an approximate mapping in PAF", {'m',"approx-map"});
     args::Flag no_merge(parser, "no-merge", "don't merge consecutive segment-level mappings", {'M', "no-merge"});
+
+    args::ValueFlag<float> pval_cutoff(parser, "N", "p-value cutoff for determining the window size [default: 1e-03]", {'w', "p-value-window-size"});
+    args::ValueFlag<float> confidence_interval(parser, "N", "confidence interval to relax the jaccard cutoff for mapping [default: 0.75]", {'c', "confidende-interval"});
+
     // align parameters
     args::ValueFlag<std::string> align_input_paf(parser, "FILE", "derive precise alignments for this input PAF", {'i', "input-paf"});
     args::ValueFlag<int> wflambda_segment_length(parser, "N", "wflambda segment length: size (in bp) of segment mapped in hierarchical WFA problem [default: 256]", {'W', "wflamda-segment"});
@@ -171,6 +175,21 @@ void parse_args(int argc,
         map_parameters.keep_low_pct_id = false;
     }
 
+    if (pval_cutoff) {
+        map_parameters.pval_cutoff = pval_cutoff ? args::get(pval_cutoff) : 1e-03;
+    }
+    if (confidence_interval) {
+        float ci = args::get(confidence_interval);
+
+        if (ci > 1 ) {
+            std::cerr << "[wfmash] ERROR, skch::parseandSave, confidence_interval must be between 0 and 1." << std::endl;
+            exit(1);
+        }
+        map_parameters.confidence_interval = ci;
+    } else {
+        map_parameters.confidence_interval = 0.75;
+    }
+
     if (keep_low_align_pct_identity) {
         align_parameters.min_identity = 0; // now unused
     } else {
@@ -215,7 +234,8 @@ void parse_args(int argc,
      */
 
     //Compute optimal window size
-    map_parameters.windowSize = skch::Stat::recommendedWindowSize(skch::fixed::pval_cutoff,
+    map_parameters.windowSize = skch::Stat::recommendedWindowSize(map_parameters.pval_cutoff,
+                                                                  map_parameters.confidence_interval,
                                                                   map_parameters.kmerSize,
                                                                   map_parameters.alphabetSize,
                                                                   map_parameters.percentageIdentity,

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -49,8 +49,8 @@ void parse_args(int argc,
     args::Flag approx_mapping(parser, "approx-map", "skip base-level alignment, producing an approximate mapping in PAF", {'m',"approx-map"});
     args::Flag no_merge(parser, "no-merge", "don't merge consecutive segment-level mappings", {'M', "no-merge"});
 
-    args::ValueFlag<float> pval_cutoff(parser, "N", "p-value cutoff for determining the window size [default: 1e-03]", {'w', "p-value-window-size"});
-    args::ValueFlag<float> confidence_interval(parser, "N", "confidence interval to relax the jaccard cutoff for mapping [default: 0.75]", {'c', "confidende-interval"});
+    args::ValueFlag<float> pval_cutoff(parser, "N", "p-value cutoff for determining the window size [default: 1e-06]", {'w', "p-value-window-size"});
+    args::ValueFlag<float> confidence_interval(parser, "N", "confidence interval to relax the jaccard cutoff for mapping [default: 0.95]", {'c', "confidende-interval"});
 
     // align parameters
     args::ValueFlag<std::string> align_input_paf(parser, "FILE", "derive precise alignments for this input PAF", {'i', "input-paf"});
@@ -175,9 +175,9 @@ void parse_args(int argc,
         map_parameters.keep_low_pct_id = false;
     }
 
-    if (pval_cutoff) {
-        map_parameters.pval_cutoff = pval_cutoff ? args::get(pval_cutoff) : 1e-03;
-    }
+
+    map_parameters.pval_cutoff = pval_cutoff ? args::get(pval_cutoff) : 1e-06;
+
     if (confidence_interval) {
         float ci = args::get(confidence_interval);
 
@@ -187,7 +187,7 @@ void parse_args(int argc,
         }
         map_parameters.confidence_interval = ci;
     } else {
-        map_parameters.confidence_interval = 0.75;
+        map_parameters.confidence_interval = 0.95;
     }
 
     if (keep_low_align_pct_identity) {


### PR DESCRIPTION
This parameter, especially the confidence interval to relax the jaccard cutoff for mapping, improve the mapping boundaries identification, without increasing too much the mapping time.