### PR TITLE
erode and patch alignments in one pass

### DIFF
--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -41,6 +41,9 @@ void wflign_affine_wavefront(
     const int pattern_length = query_length / step_size;
     const int text_length = target_length / step_size;
 
+    // patching bound
+    const uint64_t max_patch_length = segment_length * 32;
+
     // uncomment to use reduced WFA locally
     // currently not supported due to issues with traceback when applying WF-reduction on small problems
     const int wfa_min_wavefront_length = 0; //segment_length / 16;
@@ -205,7 +208,7 @@ void wflign_affine_wavefront(
 
     // Trim alignments that overlap in the query
     if (!trace.empty()) {
-#define VALIDATE_WFA_WFLIGN
+//#define VALIDATE_WFA_WFLIGN
 #ifdef VALIDATE_WFA_WFLIGN
         if (!trace.front()->validate(query, target)) {
             std::cerr << "first traceback is wrong" << std::endl;
@@ -326,7 +329,7 @@ void wflign_affine_wavefront(
                                    target,
                                    target_name, target_total_length, target_offset, target_length,
                                    min_identity,
-                                   segment_length * 128,
+                                   max_patch_length,
                                    elapsed_time_wflambda_ms);
         } else {
             for (auto x = trace.rbegin(); x != trace.rend(); ++x) {
@@ -1052,36 +1055,6 @@ void write_merged_alignment(
                                 for (int i = 0; i < *result.startLocations; ++i) {
                                     tracev.push_back('D');
                                 }
-
-                                /*std::vector<char> headv;
-                                char moveCodeToChar[] = {'M', 'I', 'D', 'X'};
-                                auto& end_idx = result.alignmentLength;
-                                for (int i = 0; i < end_idx; ++i) {
-                                    headv.push_back(moveCodeToChar[result.alignment[i]]);
-                                }
-                                // now add the tail stuff
-                                // count the ref distance
-                                uint64_t qlen = 0;
-                                uint64_t tlen = 0;
-                                for (auto& c : headv) {
-                                    switch (c) {
-                                    case 'M': case 'X':
-                                        ++qlen; ++tlen; break;
-                                    case 'I': ++qlen; break;
-                                    case 'D': ++tlen; break;
-                                    default: break;
-                                    }
-                                }
-                                while (tlen++ < target_delta) {
-                                    headv.push_back('D');
-                                }
-                                while (qlen++ < query_delta) {
-                                    headv.push_back('I');
-                                }
-                                std::reverse(headv.begin(), headv.end());
-                                for (auto& c : headv) {
-                                    tracev.push_back(c);
-                                }*/
                             }
                             edlibFreeAlignResult(result);
                         }

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -544,7 +544,7 @@ bool hack_cigar(
     bool ok = true;
     //std::cerr << "start to end " << start_idx << " " << end_idx << std::endl;
     for (int c = start_idx; c < end_idx; c++) {
-        if (j >= j_max && i >= i_max) {
+        if (j >= j_max || i >= i_max) {
             cigar.end_offset = c;
             ok = false;
             break;

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -544,7 +544,7 @@ bool hack_cigar(
     bool ok = true;
     //std::cerr << "start to end " << start_idx << " " << end_idx << std::endl;
     for (int c = start_idx; c < end_idx; c++) {
-        if (j >= j_max || i >= i_max) {
+        if (j >= j_max && i >= i_max) {
             cigar.end_offset = c;
             ok = false;
             break;
@@ -553,7 +553,7 @@ bool hack_cigar(
         switch (cigar.operations[c]) {
         case 'M':
             // check that we match
-            if (query[j] != target[i]) {
+            if (j < j_max && i < i_max && query[j] != target[i]) {
                 //std::cerr << "mismatch @ " << j << " " << i << " " << query[j] << " " << target[i] << std::endl;
                 cigar.operations[c] = 'X';
                 ok = false;

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -1028,8 +1028,10 @@ void write_merged_alignment(
 
                 if (query_delta > 0) {
                     // there is a piece of query
-                    auto target_delta_x = (target_pos + target_delta + query_delta < target_total_length ?
-                                    target_delta + query_delta : target_pos + target_delta + query_delta - target_total_length);
+                    auto target_delta_x = target_delta +
+                            (target_pos + target_delta + query_delta < target_total_length ?
+                                    query_delta :
+                                    target_total_length - (target_pos + target_delta));
 
                     auto result = do_edlib_patch_alignment(
                             query, query_pos, query_delta,

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -1038,7 +1038,22 @@ void write_merged_alignment(
                                 && result.editDistance >= 0) {
                                 got_alignment = true;
 
-                                std::vector<char> headv;
+                               for (int i = *result.endLocations + 1; i < target_delta; ++i) {
+                                   tracev.push_back('D');
+                               }
+
+                                // copy it into the trace
+                                char moveCodeToChar[] = {'M', 'I', 'D', 'X'};
+                                auto& end_idx = result.alignmentLength;
+                                for (int i = end_idx - 1; i >= 0; --i) {
+                                    tracev.push_back(moveCodeToChar[result.alignment[i]]);
+                                }
+
+                                for (int i = 0; i < *result.startLocations; ++i) {
+                                    tracev.push_back('D');
+                                }
+
+                                /*std::vector<char> headv;
                                 char moveCodeToChar[] = {'M', 'I', 'D', 'X'};
                                 auto& end_idx = result.alignmentLength;
                                 for (int i = 0; i < end_idx; ++i) {
@@ -1066,7 +1081,7 @@ void write_merged_alignment(
                                 std::reverse(headv.begin(), headv.end());
                                 for (auto& c : headv) {
                                     tracev.push_back(c);
-                                }
+                                }*/
                             }
                             edlibFreeAlignResult(result);
                         }

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -822,7 +822,7 @@ void write_merged_alignment(
             for (uint64_t i = 0; i < rawv.size(); ) {
                 if (rawv[i] == 'M') {
                     uint64_t j = i;
-                    while (j < rawv.size() && rawv[++j] == 'M') { }
+                    while (++j < rawv.size() && rawv[j] == 'M') { }
                     if (j-i < erode_k) {
                         while (i < j) {
                             erodev.push_back('D');

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -933,7 +933,7 @@ void write_merged_alignment(
                     std::cerr << "q: " << query[query_pos] << " "
                               << "t: " << target[target_pos] << std::endl;
                     */
-                    if (query_pos >= query_length || target_pos >= target_length) {
+                    if (query_pos >= query_length || target_pos >= target_length_mut) {
                         std::cerr << "[wflign::wflign_affine_wavefront] corrupted traceback (out of bounds) for "
                                   << query_name << " " << query_offset << " "
                                   << target_name << " " << target_offset << std::endl;
@@ -1104,7 +1104,8 @@ void write_merged_alignment(
                         && result.editDistance >= 0) {
                         got_alignment = true;
 
-                        if (target_pos + target_delta_x > target_length) {
+                        if (target_pos + target_delta_x > target_length_mut) {
+                            target_end += (target_pos + target_delta_x - target_length_mut);
                             target_length_mut = target_pos + target_delta_x;
                         }
 

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -792,6 +792,7 @@ void write_merged_alignment(
     const uint64_t min_edlib_length = 0;
     const int min_wf_length = 64;
     const int max_dist_threshold = 512;
+    const uint64_t max_edlib_tail_length = 2000;
 
     // we need to get the start position in the query and target
     // then run through the whole alignment building up the cigar
@@ -1025,7 +1026,7 @@ void write_merged_alignment(
 
                 bool got_alignment = false;
 
-                if (query_delta > 0) {
+                if (query_delta > 0 && query_delta <= max_edlib_tail_length) {
                     // there is a piece of query
                     auto target_delta_x = target_delta +
                             (target_pos + target_delta + query_delta < target_total_length ?

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -473,13 +473,13 @@ void do_wfa_patch_alignment(
     if (min_wavefront_length || max_distance_threshold) {
         // adaptive affine WFA setup
         affine_wavefronts = affine_wavefronts_new_reduced(
-            target_length * 2, query_length * 2, affine_penalties,
+            target_length, query_length, affine_penalties,
             min_wavefront_length, max_distance_threshold,
             NULL, mm_allocator);
     } else {
         // exact WFA
         affine_wavefronts = affine_wavefronts_new_complete(
-            target_length * 2, query_length * 2, affine_penalties, NULL, mm_allocator);
+            target_length, query_length, affine_penalties, NULL, mm_allocator);
     }
 
     aln.j = j;

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -28,6 +28,11 @@ void wflign_affine_wavefront(
     //const int& wfa_min_wavefront_length, // with these set at 0 we do exact WFA for WFA itself
     //const int& wfa_max_distance_threshold) {
 
+    if (query_offset + query_length > query_total_length
+        || target_offset + target_length > target_total_length) {
+        return;
+    }
+
     // set up our implicit matrix
     const uint64_t steps_per_segment = 2;
     const uint64_t step_size = segment_length / steps_per_segment;

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -205,7 +205,7 @@ void wflign_affine_wavefront(
 
     // Trim alignments that overlap in the query
     if (!trace.empty()) {
-#define VALIDATE_WFA_WFLIGN
+//#define VALIDATE_WFA_WFLIGN
 #ifdef VALIDATE_WFA_WFLIGN
         if (!trace.front()->validate(query, target)) {
             std::cerr << "first traceback is wrong" << std::endl;
@@ -468,6 +468,7 @@ void do_wfa_patch_alignment(
     alignment_t& aln) {
 
     //std::cerr << "do_wfa_patch " << j << " " << query_length << " " << i << " " << target_length << std::endl;
+    wfa::mm_allocator_clear(mm_allocator);
 
     wfa::affine_wavefronts_t* affine_wavefronts;
     if (min_wavefront_length || max_distance_threshold) {
@@ -971,6 +972,12 @@ void write_merged_alignment(
                         alignment_t patch_aln;
 #ifdef WFLIGN_DEBUG
                         std::cerr << "do_wfa_patch_alignment" << std::endl;
+#endif
+#ifdef WFLIGN_SHOW_PATCH
+                        std::cerr << "[wflign::wflign_affine_wavefront] patching in "
+                                  << query_name << " " << query_offset << " @ " << query_pos
+                                  << target_name << " " << target_offset << " @ " << target_pos
+                                  << std::endl;
 #endif
                         do_wfa_patch_alignment(
                             query, query_pos, query_delta,

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -939,6 +939,7 @@ void write_merged_alignment(
                                 tracev.push_back(moveCodeToChar[result.alignment[i]]);
                             }
                         }
+                        edlibFreeAlignResult(result);
                     }
                 }
                 // add in stuff if we didn't align

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -320,7 +320,7 @@ void wflign_affine_wavefront(
                                    target,
                                    target_name, target_total_length, target_offset, target_length,
                                    min_identity,
-                                   segment_length * 32,
+                                   segment_length * 128,
                                    elapsed_time_wflambda_ms);
         } else {
             for (auto x = trace.rbegin(); x != trace.rend(); ++x) {
@@ -733,8 +733,8 @@ void write_merged_alignment(
     // patching parameters
     const uint64_t min_wfa_length = 16;
     const uint64_t min_edlib_length = 0;
-    const int min_wf_length = 8;
-    const int max_dist_threshold = 128;
+    const int min_wf_length = 16;
+    const int max_dist_threshold = 512;
 
     // we need to get the start position in the query and target
     // then run through the whole alignment building up the cigar
@@ -896,7 +896,7 @@ void write_merged_alignment(
                 bool got_alignment = false;
                 if (last_match_query > -1 && last_match_target > -1 &&
                     query_delta > 0 && target_delta > 0 &&
-                    query_delta < dropout_rescue_max && target_delta < dropout_rescue_max) {
+                    (query_delta < dropout_rescue_max || target_delta < dropout_rescue_max)) {
 
                     uint64_t patch_target_aligned_length = 0;
                     uint64_t patch_query_aligned_length = 0;

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -1315,7 +1315,7 @@ void write_merged_alignment(
                 << "\t" << matches
                 << "\t" << std::max(total_target_aligned_length, total_query_aligned_length)
                 << "\t" << std::round(float2phred(1.0-block_identity))
-                << "\t" << "as:i:" << total_score
+                //<< "\t" << "as:i:" << total_score
                 << "\t" << "gi:f:" << gap_compressed_identity
                 << "\t" << "bi:f:" << block_identity
                 //<< "\t" << "md:f:" << mash_dist_sum / trace.size()
@@ -1378,7 +1378,7 @@ void write_merged_alignment(
 
             out << "\t" << "*"                                                  // ASCII of Phred-scaled base QUALity+33
                 << "\t" << "NM:i:" << edit_distance
-                << "\t" << "AS:i:" << total_score
+                //<< "\t" << "AS:i:" << total_score
                 << "\t" << "gi:f:" << gap_compressed_identity
                 << "\t" << "bi:f:" << block_identity
                 //<< "\t" << "md:f:" << mash_dist_sum / trace.size()

--- a/src/common/wflign/src/wflign_wfa.hpp
+++ b/src/common/wflign/src/wflign_wfa.hpp
@@ -304,6 +304,8 @@ void write_alignment(
 
 char* alignment_to_cigar(
     const std::vector<char>& edit_cigar,
+    const uint64_t& start_idx,
+    const uint64_t& end_idx,
     uint64_t& target_aligned_length,
     uint64_t& query_aligned_length,
     uint64_t& matches,

--- a/src/common/wflign/src/wflign_wfa.hpp
+++ b/src/common/wflign/src/wflign_wfa.hpp
@@ -34,6 +34,12 @@ bool validate_cigar(
     const uint64_t& query_aln_len, const uint64_t& target_aln_len,
     uint64_t j, uint64_t i);
 
+bool validate_trace(
+    const std::vector<char>& tracev,
+    const char* query, const char* target,
+    const uint64_t& query_aln_len, const uint64_t& target_aln_len,
+    uint64_t j, uint64_t i);
+
 bool unpack_display_cigar(
     const wfa::edit_cigar_t& cigar,
     const char* query, const char* target,

--- a/src/common/wflign/src/wflign_wfa.hpp
+++ b/src/common/wflign/src/wflign_wfa.hpp
@@ -257,7 +257,8 @@ EdlibAlignResult do_edlib_patch_alignment(
     const uint64_t& query_length,
     const char* target,
     const uint64_t& i,
-    const uint64_t& target_length);
+    const uint64_t& target_length,
+    const EdlibAlignMode align_mode);
 
 void merge_alignments(
     alignment_t& base,

--- a/src/common/wflign/src/wflign_wfa.hpp
+++ b/src/common/wflign/src/wflign_wfa.hpp
@@ -173,6 +173,10 @@ void wflign_edit_cigar_copy(
     wfa::edit_cigar_t* const edit_cigar_dst,
     wfa::edit_cigar_t* const edit_cigar_src);
 
+void copy_wfa_alignment_into_trace(
+    const wfa::edit_cigar_t* const edit_cigar,
+    std::vector<char>& trace);
+
 /*
 void edlib_to_wflign_edit_cigar_copy(
     wfa::edit_cigar_t* const edit_cigar_dst,
@@ -291,6 +295,16 @@ void write_alignment(
     const float& min_identity,
     const bool& with_endline = true);
 
+char* alignment_to_cigar(
+    const std::vector<char>& edit_cigar,
+    uint64_t& target_aligned_length,
+    uint64_t& query_aligned_length,
+    uint64_t& matches,
+    uint64_t& mismatches,
+    uint64_t& insertions,
+    uint64_t& inserted_bp,
+    uint64_t& deletions,
+    uint64_t& deleted_bp);
 
 char* wfa_alignment_to_cigar(
     const wfa::edit_cigar_t* const edit_cigar,
@@ -316,6 +330,8 @@ char* edlib_alignment_to_cigar(
     uint64_t& deleted_bp);
 
 double float2phred(const double& prob);
+
+void sort_indels(std::vector<char>& v);
 
 }
 

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -41,7 +41,7 @@ void parse_args(int argc,
     args::ValueFlag<float> map_pct_identity(parser, "%", "use this percent identity in the mashmap step [default: 95]", {'p', "map-pct-id"});
     args::Flag keep_low_map_pct_identity(parser, "K", "keep mappings with estimated identity below --map-pct-id=%", {'K', "keep-low-map-id"});
     args::Flag keep_low_align_pct_identity(parser, "A", "keep alignments with gap-compressed identity below --map-pct-id=%", {'O', "keep-low-align-id"});
-    args::ValueFlag<std::string> map_filter_mode(parser, "MODE", "filter mode for map step, either 'map', 'one-to-one', or 'none' [default: 'one-to-one']", {'f', "map-filter-mode"});
+    args::Flag no_filter(parser, "MODE", "disable mapping filtering", {'f', "no-filter"});
     args::ValueFlag<int> map_secondaries(parser, "N", "number of secondary mappings to retain in 'map' filter mode (total number of mappings is this + 1) [default: 0]", {'n', "n-secondary"});
     args::ValueFlag<int> map_short_secondaries(parser, "N", "number of secondary mappings to retain for sequences shorter than segment length [default: 0]", {'S', "n-short-secondary"});
     args::Flag skip_self(parser, "", "skip self mappings when the query and target name is the same (for all-vs-all mode)", {'X', "skip-self"});
@@ -111,18 +111,14 @@ void parse_args(int argc,
     
     map_parameters.alphabetSize = 4;
 
-    if (map_filter_mode) {
-        auto& filter_input = args::get(map_filter_mode);
-        if (filter_input == "map") map_parameters.filterMode = skch::filter::MAP;
-        else if (filter_input == "one-to-one") map_parameters.filterMode = skch::filter::ONETOONE;
-        else if (filter_input == "none") map_parameters.filterMode = skch::filter::NONE;
-        else 
-        {
-            std::cerr << "[wfmash] ERROR, skch::parseandSave, Invalid option given for filter_mode" << std::endl;
-            exit(1);
-        }
+    if (no_filter) {
+        map_parameters.filterMode = skch::filter::NONE;
     } else {
-        map_parameters.filterMode = skch::filter::ONETOONE;
+        if (skip_self || skip_prefix) {
+            map_parameters.filterMode = skch::filter::ONETOONE;
+        } else {
+            map_parameters.filterMode = skch::filter::MAP;
+        }
     }
 
     align_parameters.emit_md_tag = args::get(emit_md_tag);

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -238,14 +238,7 @@ void parse_args(int argc,
                                                                   map_parameters.segLength,
                                                                   map_parameters.referenceSize);
 
-
-    if (align_input_paf) {
-        map_parameters.outFileName = "";
-        yeet_parameters.approx_mapping = false;
-        yeet_parameters.align_input_paf = true;
-        align_parameters.mashmapPafFile = args::get(align_input_paf);
-        align_parameters.pafOutputFile = "/dev/stdout";
-    } else if (approx_mapping) {
+    if (approx_mapping) {
         map_parameters.outFileName = "/dev/stdout";
         yeet_parameters.approx_mapping = true;
     } else {


### PR DESCRIPTION
This updates wflign_wfa to:

1. collect all tracebacks into one trace vector
2. erode the represented cigar by replacing short matches with an equivalent insertion + deletion
3. sort the cigar to put insertions before deletions
4. patch regions of the cigar where we jump simultaneously in query and target by re-running WFA locally
5. merge the final cigar as before

We may want to tweak the patching parameters to run WFA on larger patches. This now hard-coded to around 32x the segment size, or 8192bp with the default 256bp segments.