### PR TITLE
spaced seeds should retain their length and "don't care" characters

### DIFF
--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -255,13 +255,15 @@ namespace skch {
             for (offset_t i = 0; i < len - seed_length + 1; i++) {
               char* forward_start_char = seq+i;
               char* reverse_start_char = seqRev + len - i - seed_length;
-              std::string new_forward_kmer, new_reverse_kmer;
+              char new_forward_kmer[seed_length];
+              char new_reverse_kmer[seed_length];
 
-              for (size_t j=0; j<seed_length; j++, ss++, forward_start_char++, reverse_start_char++) {
-                if (*ss == '1') {
-                  new_forward_kmer.push_back(*forward_start_char);
-                  new_reverse_kmer.push_back(*reverse_start_char);
-                }
+              for (size_t j=0; j<seed_length; ++j, ++ss, ++forward_start_char) {
+                  new_forward_kmer[j] = *ss == '1' ? *forward_start_char : '*';
+              }
+              ss = s.seed;
+              for (size_t j=0; j<seed_length; ++j, ++ss, ++reverse_start_char) {
+                  new_reverse_kmer[j] = *ss == '1' ? *reverse_start_char : '*';
               }
               ss = s.seed; // reset the seed for the next iteration of the loop
 

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -163,7 +163,7 @@ void parse_args(int argc,
       auto spaced_seed_params = skch::ales_params{seed_weight, seed_count, similarity, region_length};
       map_parameters.use_spaced_seeds = true;
       map_parameters.spaced_seed_params = spaced_seed_params;
-      map_parameters.kmerSize = seed_weight;
+      map_parameters.kmerSize = seed_weight * seed_count;
     } else {
       map_parameters.use_spaced_seeds = false;
     }
@@ -290,6 +290,10 @@ void parse_args(int argc,
                                                                   map_parameters.percentageIdentity,
                                                                   map_parameters.segLength,
                                                                   map_parameters.referenceSize);
+
+    if (map_parameters.use_spaced_seeds) {
+        map_parameters.windowSize *= map_parameters.spaced_seed_params.seed_count;
+    }
 
     if (approx_mapping) {
         map_parameters.outFileName = "/dev/stdout";

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -111,6 +111,11 @@ void parse_args(int argc,
         skch::parseFileList(args::get(query_sequence_file_list), align_parameters.querySequences);
     }
 
+    if (kmer_size) {
+        map_parameters.kmerSize = args::get(kmer_size);
+    } else {
+        map_parameters.kmerSize = 16;
+    }
 
     if (spaced_seed_params) {
 
@@ -158,6 +163,7 @@ void parse_args(int argc,
       auto spaced_seed_params = skch::ales_params{seed_weight, seed_count, similarity, region_length};
       map_parameters.use_spaced_seeds = true;
       map_parameters.spaced_seed_params = spaced_seed_params;
+      map_parameters.kmerSize = seed_weight;
     } else {
       map_parameters.use_spaced_seeds = false;
     }
@@ -184,12 +190,6 @@ void parse_args(int argc,
     }
 
     map_parameters.mergeMappings = !args::get(no_merge);
-
-    if (kmer_size) {
-        map_parameters.kmerSize = args::get(kmer_size);
-    } else {
-        map_parameters.kmerSize = 16;
-    }
 
     if (segment_length) {
         map_parameters.segLength = args::get(segment_length);


### PR DESCRIPTION
with pattern extraction rendered in easily-vectorizable loops