### PR TITLE
fixed dummy window indicator

### DIFF
--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -179,9 +179,9 @@ namespace skch {
                         Q.pop_back();
 
                     //Push currentKmer and position to back of the queue
-                    //0 indicates the dummy window # (will be updated later)
+                    //-1 indicates the dummy window # (will be updated later)
                     Q.push_back(std::make_pair(
-                            MinimizerInfo{currentKmer, seqCounter, 0, currentStrand},
+                            MinimizerInfo{currentKmer, seqCounter, -1, currentStrand},
                             i));
 
                     //Select the minimizer from Q and put into index


### PR DESCRIPTION
If the first kmer of a sequence is considered as a minimizer, it will have position 0, and the same kmer will not be considered in other positions as 0 coincides with the dummy window indicator

An example here https://github.com/marbl/MashMap/pull/32.