### PR TITLE
use 32-bit hashes for wflign mash guidance

### DIFF
--- a/src/common/wflign/src/rkmh.cpp
+++ b/src/common/wflign/src/rkmh.cpp
@@ -44,14 +44,14 @@ inline void reverse_complement(const char *seq, char *ret, int len) {
 inline void calc_hashes_(const char *seq, const uint64_t &len,
                          const uint64_t &k, hash_t *&hashes, int numhashes) {
     char reverse[k + 1];
-    uint32_t rhash;//[4];
-    uint32_t fhash;//[4];
+    char rhash[16];
+    char fhash[16];
     for (int i = 0; i < numhashes; ++i) {
         reverse_complement(seq + i, reverse, k);
-        MurmurHash3_x86_32(seq + i, k, 42, &fhash);
-        MurmurHash3_x86_32(reverse, k, 42, &rhash);
-        hash_t tmp_fwd = fhash; //static_cast<uint32_t>(fhash[0]) << 32 | fhash[1];
-        hash_t tmp_rev = rhash; //static_cast<uint32_t>(rhash[0]) << 32 | rhash[1];
+        MurmurHash3_x64_128(seq + i, k, 42, &fhash);
+        MurmurHash3_x64_128(reverse, k, 42, &rhash);
+        hash_t tmp_fwd = *((hash_t*)fhash);
+        hash_t tmp_rev = *((hash_t*)rhash);
         hashes[i] = (tmp_fwd < tmp_rev ? tmp_fwd : tmp_rev);
         //std::cerr << "hashes[" << i << "] = " << hashes[i] << std::endl;
     }

--- a/src/common/wflign/src/rkmh.cpp
+++ b/src/common/wflign/src/rkmh.cpp
@@ -44,14 +44,14 @@ inline void reverse_complement(const char *seq, char *ret, int len) {
 inline void calc_hashes_(const char *seq, const uint64_t &len,
                          const uint64_t &k, hash_t *&hashes, int numhashes) {
     char reverse[k + 1];
-    uint32_t rhash[4];
-    uint32_t fhash[4];
+    uint32_t rhash;//[4];
+    uint32_t fhash;//[4];
     for (int i = 0; i < numhashes; ++i) {
         reverse_complement(seq + i, reverse, k);
-        MurmurHash3_x64_128(seq + i, k, 42, fhash);
-        MurmurHash3_x64_128(reverse, k, 42, rhash);
-        hash_t tmp_fwd = static_cast<uint64_t>(fhash[0]) << 32 | fhash[1];
-        hash_t tmp_rev = static_cast<uint64_t>(rhash[0]) << 32 | rhash[1];
+        MurmurHash3_x86_32(seq + i, k, 42, &fhash);
+        MurmurHash3_x86_32(reverse, k, 42, &rhash);
+        hash_t tmp_fwd = fhash; //static_cast<uint32_t>(fhash[0]) << 32 | fhash[1];
+        hash_t tmp_rev = rhash; //static_cast<uint32_t>(rhash[0]) << 32 | rhash[1];
         hashes[i] = (tmp_fwd < tmp_rev ? tmp_fwd : tmp_rev);
         //std::cerr << "hashes[" << i << "] = " << hashes[i] << std::endl;
     }

--- a/src/common/wflign/src/rkmh.hpp
+++ b/src/common/wflign/src/rkmh.hpp
@@ -40,7 +40,7 @@ static char rev_arr[26] = {
         85, 86, 87, 88, 89, 90
 };
 
-typedef uint64_t hash_t;
+typedef uint32_t hash_t;
 
 std::vector<hash_t> hash_sequence(const char* seq,
                                   const uint64_t& len,

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -394,11 +394,11 @@ bool do_wfa_segment_alignment(
     // first make the sketches if we haven't yet
     if (query_sketch == nullptr) {
         query_sketch = new std::vector<rkmh::hash_t>();
-        *query_sketch = rkmh::hash_sequence(query+j, segment_length, minhash_kmer_size, segment_length/8);
+        *query_sketch = rkmh::hash_sequence(query+j, segment_length, minhash_kmer_size, segment_length/4);
     }
     if (target_sketch == nullptr) {
         target_sketch = new std::vector<rkmh::hash_t>();
-        *target_sketch = rkmh::hash_sequence(target+i, segment_length, minhash_kmer_size, segment_length/8);
+        *target_sketch = rkmh::hash_sequence(target+i, segment_length, minhash_kmer_size, segment_length/4);
     }
 
     // first check if our mash dist is inbounds

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -394,11 +394,11 @@ bool do_wfa_segment_alignment(
     // first make the sketches if we haven't yet
     if (query_sketch == nullptr) {
         query_sketch = new std::vector<rkmh::hash_t>();
-        *query_sketch = rkmh::hash_sequence(query+j, segment_length, minhash_kmer_size, segment_length/4);
+        *query_sketch = rkmh::hash_sequence(query+j, segment_length, minhash_kmer_size, segment_length/8);
     }
     if (target_sketch == nullptr) {
         target_sketch = new std::vector<rkmh::hash_t>();
-        *target_sketch = rkmh::hash_sequence(target+i, segment_length, minhash_kmer_size, segment_length/4);
+        *target_sketch = rkmh::hash_sequence(target+i, segment_length, minhash_kmer_size, segment_length/8);
     }
 
     // first check if our mash dist is inbounds


### PR DESCRIPTION
Same memory, similar time, maybe more sensitive.