### PR TITLE
filter less work more

### DIFF
--- a/src/map/include/base_types.hpp
+++ b/src/map/include/base_types.hpp
@@ -123,7 +123,6 @@ namespace skch
 
     offset_t splitMappingId;                            // To identify split mappings that are chained
     int discard;                                        // set to 1 for deletion
-    bool selfMapFilter;                                 // set to true if a long-to-short mapping in all-vs-all mode (we report short as the query)
 
     offset_t qlen() {                                   //length of this mapping on query axis 
       return queryEndPos - queryStartPos + 1;

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -248,23 +248,6 @@ namespace skch
 
       /**
        * @brief               helper to main mapping function
-       * @details             filters long-to-short mappings if we're in an all-vs-all mode
-       * @param[in]   input   mappings
-       * @return              void
-       */
-      void filterSelfingLongToShorts(MappingResultsVector_t &readMappings)
-      {
-          if (param.skip_self || param.skip_prefix) {
-              readMappings.erase(
-                  std::remove_if(readMappings.begin(),
-                                 readMappings.end(),
-                                 [&](MappingResult &e){ return e.selfMapFilter == true; }),
-                  readMappings.end());
-          }
-      }
-
-      /**
-       * @brief               helper to main mapping function
        * @details             filters mappings whose identity and query/ref length don't agree
        * @param[in]   input   mappings
        * @return              void
@@ -395,12 +378,6 @@ namespace skch
         if (split_mapping) {
             this->filterShortMappings(output->readMappings);
         }
-
-        // remove self-mode don't-maps
-        this->filterSelfingLongToShorts(output->readMappings);
-
-        // remove alignments where the ratio between query and target length is < our identity threshold
-        this->filterFalseHighIdentity(output->readMappings);
 
         //Make sure mapping boundary don't exceed sequence lengths
         this->mappingBoundarySanityCheck(input, output->readMappings);
@@ -663,8 +640,6 @@ namespace skch
                 res.conservedSketches = l2.sharedSketchSize;
                 res.blockLength = std::max(res.refEndPos - res.refStartPos, res.queryEndPos - res.queryStartPos);
                 res.approxMatches = std::round(res.nucIdentity * res.blockLength / 100.0);
-
-                res.selfMapFilter = ((param.skip_self || param.skip_prefix) && Q.fullLen > ref.len);
 
                 //Compute additional statistics -> strand, reference complexity
                 {


### PR DESCRIPTION
This removes a filter that attempt to take the upper triangular portion of the all-to-all alignment matrix, and another that drops mappings whose length and identity are in disagreement. These are likely to contain SVs.