### PR TITLE
adapt the wflign_segment_length to the shortest sequence

### DIFF
--- a/src/common/wflign/src/wflign_wfa.hpp
+++ b/src/common/wflign/src/wflign_wfa.hpp
@@ -237,8 +237,8 @@ bool do_wfa_segment_alignment(
     const uint64_t& segment_length,
     const uint64_t& step_size,
     const uint64_t& minhash_kmer_size,
-    const int min_wavefront_length,
-    const int max_distance_threshold,
+    const uint32_t min_wavefront_length,
+    const uint32_t max_distance_threshold,
     wfa::mm_allocator_t* const mm_allocator,
     wfa::affine_penalties_t* const affine_penalties,
     alignment_t& aln);


### PR DESCRIPTION
The adaptation to the shorter sequence allows us to manage cases in which the 2 sequences have very different lengths and avoids impolite memory readings.