### PR TITLE
take a little nibble to always patch with WFA

### DIFF
--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -809,8 +809,7 @@ void write_merged_alignment(
 
     // patching parameters
     // we will nibble patching back to this length
-    // for affine WFA to be correct, it must be at least 10
-    const uint16_t min_patch_length = 112;
+    const uint8_t min_wfa_patch_length = 112;
     const int min_wf_length = 64;
     const int max_dist_threshold = 256;
     const uint16_t max_edlib_head_tail_patch_length = 2000;
@@ -997,14 +996,14 @@ void write_merged_alignment(
                         (query_delta < wflign_max_len_minor || target_delta < wflign_max_len_minor)) {
 #ifdef WFLIGN_DEBUG
                         std::cerr << "[wflign::wflign_affine_wavefront] patching in "
-                              << query_name << " " << query_offset << " @ " << query_pos
-                              << target_name << " " << target_offset << " @ " << target_pos
-                              << std::endl;
+                                      << query_name << " " << query_offset << " @ " << query_pos << " - " << query_delta << " "
+                                      << target_name << " " << target_offset << " @ " << target_pos << " - " << target_delta
+                                      << std::endl;
 #endif
 
                         // nibble forward/backward if we're below the correct length
                         bool nibble_fwd = true;
-                        while (q != erodev.end() && (query_delta < min_patch_length || target_delta < min_patch_length)) {
+                        while (q != erodev.end() && (query_delta < min_wfa_patch_length || target_delta < min_wfa_patch_length)) {
                             if (nibble_fwd) {
                                 const auto& c = *q++;
                                 switch (c) {
@@ -1032,7 +1031,8 @@ void write_merged_alignment(
                         }
 
                         // we need to be sure that our nibble made the problem long enough
-                        if (query_delta >= min_patch_length && target_delta >= min_patch_length) {
+                        // For affine WFA to be correct (to avoid trace-back errors), it must be at least 10 nt
+                        if (query_delta >= 10 && target_delta >= 10) {
                             alignment_t patch_aln;
                             // WFA is only global
                             do_wfa_patch_alignment(

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -809,7 +809,7 @@ void write_merged_alignment(
 
     // patching parameters
     // we will nibble patching back to this length
-    const uint8_t min_wfa_patch_length = 112;
+    const uint64_t min_wfa_patch_length = 128;
     const int min_wf_length = 64;
     const int max_dist_threshold = 256;
     const uint16_t max_edlib_head_tail_patch_length = 2000;
@@ -1001,9 +1001,10 @@ void write_merged_alignment(
                                       << std::endl;
 #endif
 
+                        uint64_t target_patch_length = std::max(min_wfa_patch_length, std::max(query_delta, target_delta)/128);
                         // nibble forward/backward if we're below the correct length
                         bool nibble_fwd = true;
-                        while (q != erodev.end() && (query_delta < min_wfa_patch_length || target_delta < min_wfa_patch_length)) {
+                        while (q != erodev.end() && (query_delta < target_patch_length || target_delta < target_patch_length)) {
                             if (nibble_fwd) {
                                 const auto& c = *q++;
                                 switch (c) {

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -1030,6 +1030,19 @@ void write_merged_alignment(
                             nibble_fwd ^= true;
                         }
 
+                        // check forward if there are other Is/Ds to merge in the current patch
+                        while (q != erodev.end() &&
+                                (*q == 'I' || *q == 'D') &&
+                                ((query_delta < wflign_max_len_major && target_delta < wflign_max_len_major) &&
+                                (query_delta < wflign_max_len_minor || target_delta < wflign_max_len_minor))) {
+                            const auto& c = *q++;
+                            if (c == 'I') {
+                                ++query_delta;
+                            } else {
+                                ++target_delta;
+                            }
+                        }
+
                         // we need to be sure that our nibble made the problem long enough
                         // For affine WFA to be correct (to avoid trace-back errors), it must be at least 10 nt
                         if (query_delta >= 10 && target_delta >= 10) {

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -810,10 +810,10 @@ void write_merged_alignment(
     // patching parameters
     // we will nibble patching back to this length
     // for affine WFA to be correct, it must be at least 10
-    const uint64_t min_patch_length = 64;
+    const uint16_t min_patch_length = 112;
     const int min_wf_length = 64;
     const int max_dist_threshold = 256;
-    const uint64_t max_edlib_tail_length = 2000;
+    const uint16_t max_edlib_tail_length = 2000;
 
     // we need to get the start position in the query and target
     // then run through the whole alignment building up the cigar
@@ -1004,8 +1004,7 @@ void write_merged_alignment(
 
                         // nibble forward/backward if we're below the correct length
                         bool nibble_fwd = true;
-                        while (q != erodev.end() && (query_delta < min_patch_length
-                                                     || target_delta < min_patch_length)) {
+                        while (q != erodev.end() && (query_delta < min_patch_length || target_delta < min_patch_length)) {
                             if (nibble_fwd) {
                                 const auto& c = *q++;
                                 switch (c) {
@@ -1032,13 +1031,10 @@ void write_merged_alignment(
                             nibble_fwd ^= true;
                         }
 
-                        uint64_t patch_target_aligned_length = 0;
-                        uint64_t patch_query_aligned_length = 0;
-
-                        // WFA is only global
                         // we need to be sure that our nibble made the problem long enough
                         if (query_delta >= min_patch_length && target_delta >= min_patch_length) {
                             alignment_t patch_aln;
+                            // WFA is only global
                             do_wfa_patch_alignment(
                                 query, query_pos, query_delta,
                                 target - target_pointer_shift, target_pos, target_delta,
@@ -1390,7 +1386,7 @@ void write_merged_alignment(
             }
         }
     };
-    //std::cerr << "target_offset: " << target_offset << " -- target_start: " << target_start << std::endl;
+
     if (gap_compressed_identity >= min_identity) {
         const long elapsed_time_patching_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count();
 
@@ -1494,6 +1490,7 @@ void write_merged_alignment(
             out << "\t" << timings << "\n";
         }
     }
+
     // always clean up
     free(cigarv);
 }

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -813,7 +813,7 @@ void write_merged_alignment(
     const uint16_t min_patch_length = 112;
     const int min_wf_length = 64;
     const int max_dist_threshold = 256;
-    const uint16_t max_edlib_tail_length = 2000;
+    const uint16_t max_edlib_head_tail_patch_length = 2000;
 
     // we need to get the start position in the query and target
     // then run through the whole alignment building up the cigar
@@ -1051,7 +1051,7 @@ void write_merged_alignment(
                             }
                         }
                     }
-                } else if (query_delta > 0) {
+                } else if (query_delta > 0 && query_delta <= max_edlib_head_tail_patch_length) {
                     // Semi-global mode for patching the heads
 
                     const uint64_t pos_to_ask = query_delta + target_delta;
@@ -1158,7 +1158,7 @@ void write_merged_alignment(
 
                 bool got_alignment = false;
 
-                if (query_delta > 0 && query_delta <= max_edlib_tail_length) {
+                if (query_delta > 0 && query_delta <= max_edlib_head_tail_patch_length) {
                     // there is a piece of query
                     auto target_delta_x = target_delta +
                             ((target_offset - target_pointer_shift) + target_pos + target_delta + query_delta < target_total_length ?

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -311,6 +311,7 @@ void parse_args(int argc,
                     map_parameters.percentageIdentity,
                     map_parameters.segLength,
                     map_parameters.referenceSize);
+            map_parameters.windowSize = std::min(256, map_parameters.windowSize);
         }
     }
 


### PR DESCRIPTION
If WFA is run on short sequences, we can get traceback errors.  A simple
trick is to always give sequences of a given length to it for patching.
Doing this requires that we nibble forward a bit of match on the other
side of the region of the alignment matrix that we're patching. This
will mean we patch more in some cases, but in practice the cost seems to
be negligible.