### PR TITLE
Robust winnowing

### DIFF
--- a/src/map/include/base_types.hpp
+++ b/src/map/include/base_types.hpp
@@ -27,6 +27,7 @@ namespace skch
     seqno_t seqId;                            //sequence or contig id
     offset_t wpos;                            //First (left-most) window position when the minimizer is saved
     strand_t strand;                          //strand information
+    double order;
 
     //Lexographical less than comparison
     bool operator <(const MinimizerInfo& x) {

--- a/src/map/include/base_types.hpp
+++ b/src/map/include/base_types.hpp
@@ -27,7 +27,7 @@ namespace skch
     seqno_t seqId;                            //sequence or contig id
     offset_t wpos;                            //First (left-most) window position when the minimizer is saved
     strand_t strand;                          //strand information
-    double order;
+    //double order;
 
     //Lexographical less than comparison
     bool operator <(const MinimizerInfo& x) {

--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -206,13 +206,14 @@ namespace skch {
                     //Take minimum value of kmer and its reverse complement
                     hash_t currentKmer = std::min(hashFwd, hashBwd);
 
-                    double order = (hashFwd < hashBwd) ?
-                                   applyWeight(seq + i, kmerSize, hashFwd, high_freq_kmers) :
-                                   applyWeight(seqRev + len - i - kmerSize, kmerSize, hashBwd, high_freq_kmers);
+//                    double order = (hashFwd < hashBwd) ?
+//                                   applyWeight(seq + i, kmerSize, hashFwd, high_freq_kmers) :
+//                                   applyWeight(seqRev + len - i - kmerSize, kmerSize, hashBwd, high_freq_kmers);
 
                     //Hashes less than equal to currentKmer are not required
                     //Remove them from Q (back)
-                    while (!Q.empty() && Q.back().first.order > order)
+//                    while (!Q.empty() && Q.back().first.order > order)
+                    while (!Q.empty() && Q.back().first.hash > currentKmer)
                         Q.pop_back();
 
 #ifdef DEBUG_WINNOWING
@@ -229,7 +230,8 @@ namespace skch {
                     //Push currentKmer and position to back of the queue
                     //-1 indicates the dummy window # (will be updated later)
                     Q.push_back(std::make_pair(
-                            MinimizerInfo{currentKmer, seqCounter, -1, currentStrand, order},
+//                            MinimizerInfo{currentKmer, seqCounter, -1, currentStrand, order},
+                            MinimizerInfo{currentKmer, seqCounter, -1, currentStrand},
                             i));
 
 #ifdef DEBUG_WINNOWING
@@ -253,7 +255,8 @@ namespace skch {
 #endif
 
                         // Robust-winnowing
-                        while (Q.size() > 1 && Q.begin()->first.order == (++Q.begin())->first.order)
+//                        while (Q.size() > 1 && Q.begin()->first.order == (++Q.begin())->first.order)
+                        while (Q.size() > 1 && Q.begin()->first.hash == (++Q.begin())->first.hash)
                             Q.pop_front();
                     }
 

--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -121,23 +121,23 @@ namespace skch {
          *					this value will determine its order for minimizer selection
          * @details	this is inspired from Chum et al.'s min-Hash and tf-idf weighting
          */
-        static inline double applyWeight(char* kmer, int kmer_size, hash_t kmer_hash, const std::unordered_set<std::string>& high_freq_kmers) {
-            double x = kmer_hash * 1.0 / UINT32_MAX;  //bring it within [0, 1]
-            //assert (x >= 0.0 && x <= 1.0);
-
-            std::string kmer_str(kmer, kmer_size);
-            if (high_freq_kmers.count(kmer_str) > 0) {
-                /* downweigting by a factor of 8 */
-                /* further aggressive downweigting may affect accuracy */
-                double p2 = x*x;
-                double p4 = p2 * p2;
-                return - 1.0 * (p4 * p4);
-            }
-            return -1.0 * x;
-
-            //range of returned value is between [-1,0]
-            //we avoid adding one for better double precision
-        }
+//        static inline double applyWeight(char* kmer, int kmer_size, hash_t kmer_hash, const std::unordered_set<std::string>& high_freq_kmers) {
+//            double x = kmer_hash * 1.0 / UINT32_MAX;  //bring it within [0, 1]
+//            //assert (x >= 0.0 && x <= 1.0);
+//
+//            std::string kmer_str(kmer, kmer_size);
+//            if (high_freq_kmers.count(kmer_str) > 0) {
+//                /* downweigting by a factor of 8 */
+//                /* further aggressive downweigting may affect accuracy */
+//                double p2 = x*x;
+//                double p4 = p2 * p2;
+//                return - 1.0 * (p4 * p4);
+//            }
+//            return -1.0 * x;
+//
+//            //range of returned value is between [-1,0]
+//            //we avoid adding one for better double precision
+//        }
 
         /**
          * @brief       compute winnowed minimizers from a given sequence and add to the index
@@ -154,8 +154,9 @@ namespace skch {
                                   int kmerSize,
                                   int windowSize,
                                   int alphabetSize,
-                                  seqno_t seqCounter,
-                                  const std::unordered_set<std::string>& high_freq_kmers) {
+                                  seqno_t seqCounter
+                                  //const std::unordered_set<std::string>& high_freq_kmers
+                                  ) {
             /**
              * Double-ended queue (saves minimum at front end)
              * Saves pair of the minimizer and the position of hashed kmer in the sequence
@@ -206,13 +207,13 @@ namespace skch {
                     //Take minimum value of kmer and its reverse complement
                     hash_t currentKmer = std::min(hashFwd, hashBwd);
 
-//                    double order = (hashFwd < hashBwd) ?
-//                                   applyWeight(seq + i, kmerSize, hashFwd, high_freq_kmers) :
-//                                   applyWeight(seqRev + len - i - kmerSize, kmerSize, hashBwd, high_freq_kmers);
+                    /*double order = (hashFwd < hashBwd) ?
+                                   applyWeight(seq + i, kmerSize, hashFwd, high_freq_kmers) :
+                                   applyWeight(seqRev + len - i - kmerSize, kmerSize, hashBwd, high_freq_kmers);*/
 
                     //Hashes less than equal to currentKmer are not required
                     //Remove them from Q (back)
-//                    while (!Q.empty() && Q.back().first.order > order)
+                    //while (!Q.empty() && Q.back().first.order > order)
                     while (!Q.empty() && Q.back().first.hash > currentKmer)
                         Q.pop_back();
 
@@ -230,7 +231,7 @@ namespace skch {
                     //Push currentKmer and position to back of the queue
                     //-1 indicates the dummy window # (will be updated later)
                     Q.push_back(std::make_pair(
-//                            MinimizerInfo{currentKmer, seqCounter, -1, currentStrand, order},
+                            //MinimizerInfo{currentKmer, seqCounter, -1, currentStrand, order},
                             MinimizerInfo{currentKmer, seqCounter, -1, currentStrand},
                             i));
 
@@ -255,7 +256,7 @@ namespace skch {
 #endif
 
                         // Robust-winnowing
-//                        while (Q.size() > 1 && Q.begin()->first.order == (++Q.begin())->first.order)
+                        //while (Q.size() > 1 && Q.begin()->first.order == (++Q.begin())->first.order)
                         while (Q.size() > 1 && Q.begin()->first.hash == (++Q.begin())->first.hash)
                             Q.pop_front();
                     }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -499,7 +499,7 @@ namespace skch
           ///1. Compute the minimizers
 
           if (param.spaced_seeds.empty()) {
-            CommonFunc::addMinimizers(Q.minimizerTableQuery, Q.seq, Q.len, param.kmerSize, param.windowSize, param.alphabetSize, Q.seqCounter, param.high_freq_kmers);
+            CommonFunc::addMinimizers(Q.minimizerTableQuery, Q.seq, Q.len, param.kmerSize, param.windowSize, param.alphabetSize, Q.seqCounter);//, param.high_freq_kmers);
           } else {
             CommonFunc::addSpacedSeedMinimizers(Q.minimizerTableQuery, Q.seq, Q.len, param.kmerSize, param.windowSize, param.alphabetSize, Q.seqCounter, param.spaced_seeds);
           }

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -499,7 +499,7 @@ namespace skch
           ///1. Compute the minimizers
 
           if (param.spaced_seeds.empty()) {
-            CommonFunc::addMinimizers(Q.minimizerTableQuery, Q.seq, Q.len, param.kmerSize, param.windowSize, param.alphabetSize, Q.seqCounter);
+            CommonFunc::addMinimizers(Q.minimizerTableQuery, Q.seq, Q.len, param.kmerSize, param.windowSize, param.alphabetSize, Q.seqCounter, param.high_freq_kmers);
           } else {
             CommonFunc::addSpacedSeedMinimizers(Q.minimizerTableQuery, Q.seq, Q.len, param.kmerSize, param.windowSize, param.alphabetSize, Q.seqCounter, param.spaced_seeds);
           }

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -55,7 +55,7 @@ struct Parameters
     double spaced_seed_sensitivity;                   //
     std::vector<ales::spaced_seed> spaced_seeds;      //
 
-    std::unordered_set<std::string> high_freq_kmers;  //
+    //std::unordered_set<std::string> high_freq_kmers;  //
 };
 
 

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -7,6 +7,7 @@
 #define SKETCH_CONFIG_HPP
 
 #include <vector>
+#include <unordered_set>
 
 #include "common/ALeS.hpp"
 
@@ -56,6 +57,8 @@ struct Parameters
     ales_params spaced_seed_params;                   //
     double spaced_seed_sensitivity;                   //
     std::vector<ales::spaced_seed> spaced_seeds;      //
+
+    std::unordered_set<std::string> high_freq_kmers;  //
 };
 
 

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -48,7 +48,7 @@ namespace skch
       const skch::Parameters &param;
 
       //Ignore top % most frequent minimizers while lookups
-      const float percentageThreshold = 0;//0.001;
+      const float percentageThreshold = 0.001;
 
       //Minimizers that occur this or more times will be ignored (computed based on percentageThreshold)
       int freqThreshold = std::numeric_limits<int>::max();

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -183,7 +183,7 @@ namespace skch
 
         //Compute minimizers in reference sequence
         if (param.spaced_seeds.empty()) {
-          skch::CommonFunc::addMinimizers(*thread_output, &(input->seq[0u]), input->len, param.kmerSize, param.windowSize, param.alphabetSize, input->seqCounter, param.high_freq_kmers);
+          skch::CommonFunc::addMinimizers(*thread_output, &(input->seq[0u]), input->len, param.kmerSize, param.windowSize, param.alphabetSize, input->seqCounter);//, param.high_freq_kmers);
         } else {
           skch::CommonFunc::addSpacedSeedMinimizers(*thread_output, &(input->seq[0u]), input->len, param.kmerSize, param.windowSize, param.alphabetSize, input->seqCounter, param.spaced_seeds);
         }
@@ -215,7 +215,7 @@ namespace skch
           minimizerPosLookupIndex[e.hash].push_back( 
               MinimizerMetaData{e.seqId, e.wpos, e.strand});
 
-            std::cout << "GREPME\t" << e.wpos << "\n";
+            //std::cout << "GREPME\t" << e.wpos << "\n";
         }
 
         std::cerr << "[wfmash::skch::Sketch::index] unique minimizers = " << minimizerPosLookupIndex.size() << std::endl;

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -48,7 +48,7 @@ namespace skch
       const skch::Parameters &param;
 
       //Ignore top % most frequent minimizers while lookups
-      const float percentageThreshold = 0.001;
+      const float percentageThreshold = 0;//0.001;
 
       //Minimizers that occur this or more times will be ignored (computed based on percentageThreshold)
       int freqThreshold = std::numeric_limits<int>::max();
@@ -183,7 +183,7 @@ namespace skch
 
         //Compute minimizers in reference sequence
         if (param.spaced_seeds.empty()) {
-          skch::CommonFunc::addMinimizers(*thread_output, &(input->seq[0u]), input->len, param.kmerSize, param.windowSize, param.alphabetSize, input->seqCounter);
+          skch::CommonFunc::addMinimizers(*thread_output, &(input->seq[0u]), input->len, param.kmerSize, param.windowSize, param.alphabetSize, input->seqCounter, param.high_freq_kmers);
         } else {
           skch::CommonFunc::addSpacedSeedMinimizers(*thread_output, &(input->seq[0u]), input->len, param.kmerSize, param.windowSize, param.alphabetSize, input->seqCounter, param.spaced_seeds);
         }
@@ -214,6 +214,8 @@ namespace skch
           // [hash value -> info about minimizer]
           minimizerPosLookupIndex[e.hash].push_back( 
               MinimizerMetaData{e.seqId, e.wpos, e.strand});
+
+            std::cout << "GREPME\t" << e.wpos << "\n";
         }
 
         std::cerr << "[wfmash::skch::Sketch::index] unique minimizers = " << minimizerPosLookupIndex.size() << std::endl;

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -51,7 +51,7 @@ void parse_args(int argc,
 
     args::ValueFlag<int> window_size(parser, "N", "window size for sketching. If 0, it computes the best window size applying 0 as p-value cutoff [default: automatically computed applying 1e-120 as p-value cutoff]", {'w', "window-size"});
 
-    args::ValueFlag<std::string> path_high_frequency_kmers(parser, "FILE", " input file containing list of high frequency kmers", {'H', "high-freq-kmers"});
+    //args::ValueFlag<std::string> path_high_frequency_kmers(parser, "FILE", " input file containing list of high frequency kmers", {'H', "high-freq-kmers"});
 
     args::ValueFlag<std::string> spaced_seed_params(parser, "spaced-seed", "Params to generate spaced seeds <weight_of_seed> <number_of_seeds> <similarity> <region_length> e.g \"10 5 0.75 20\"", {'e', "spaced-seed"});
 
@@ -236,22 +236,21 @@ void parse_args(int argc,
         map_parameters.keep_low_pct_id = false;
     }
 
-    if (path_high_frequency_kmers && !args::get(path_high_frequency_kmers).empty()) {
-        std::ifstream high_freq_kmers (args::get(path_high_frequency_kmers));
-
-        std::string kmer;
-        uint64_t cnt = 0;
-        uint64_t freq;
-        while(high_freq_kmers >> kmer >> freq) {
-            if (kmer.length() != map_parameters.kmerSize) {
-                std::cerr << "[wfmash] ERROR, skch::parseandSave, high frequency k-mers length and kmerSize parameter are inconsistent." << std::endl;
-                exit(1);
-            }
-
-            map_parameters.high_freq_kmers.insert(kmer);
-        }
-        std::cerr << "[wfmash] INFO, skch::parseandSave, read " << map_parameters.high_freq_kmers.size() << " high frequency kmers." << std::endl;
-    }
+//    if (path_high_frequency_kmers && !args::get(path_high_frequency_kmers).empty()) {
+//        std::ifstream high_freq_kmers (args::get(path_high_frequency_kmers));
+//
+//        std::string kmer;
+//        uint64_t freq;
+//        while(high_freq_kmers >> kmer >> freq) {
+//            if (kmer.length() != map_parameters.kmerSize) {
+//                std::cerr << "[wfmash] ERROR, skch::parseandSave, high frequency k-mers length and kmerSize parameter are inconsistent." << std::endl;
+//                exit(1);
+//            }
+//
+//            map_parameters.high_freq_kmers.insert(kmer);
+//        }
+//        std::cerr << "[wfmash] INFO, skch::parseandSave, read " << map_parameters.high_freq_kmers.size() << " high frequency kmers." << std::endl;
+//    }
 
     if (keep_low_align_pct_identity) {
         align_parameters.min_identity = 0; // now unused

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -52,6 +52,8 @@ void parse_args(int argc,
     args::ValueFlag<double> pval_cutoff(parser, "N", "p-value cutoff for determining the window size [default: 1e-120]", {'w', "p-value-window-size"});
     args::ValueFlag<float> confidence_interval(parser, "N", "confidence interval to relax the jaccard cutoff for mapping [default: 0.95]", {'c', "confidence-interval"});
 
+    args::ValueFlag<std::string> path_high_frequency_kmers(parser, "FILE", " input file containing list of high frequency kmers", {'H', "high-freq-kmers"});
+
     args::ValueFlag<std::string> spaced_seed_params(parser, "spaced-seed", "Params to generate spaced seeds <weight_of_seed> <number_of_seeds> <similarity> <region_length> e.g \"10 5 0.75 20\"", {'e', "spaced-seed"});
 
     // align parameters
@@ -238,6 +240,24 @@ void parse_args(int argc,
     } else {
         map_parameters.confidence_interval = 0.95;
     }
+
+    if (path_high_frequency_kmers && !args::get(path_high_frequency_kmers).empty()) {
+        std::ifstream high_freq_kmers (args::get(path_high_frequency_kmers));
+
+        std::string kmer;
+        uint64_t cnt = 0;
+        uint64_t freq;
+        while(high_freq_kmers >> kmer >> freq) {
+            if (kmer.length() != map_parameters.kmerSize) {
+                std::cerr << "[wfmash] ERROR, skch::parseandSave, high frequency k-mers length and kmerSize parameter are inconsistent." << std::endl;
+                exit(1);
+            }
+
+            map_parameters.high_freq_kmers.insert(kmer);
+        }
+        std::cerr << "[wfmash] INFO, skch::parseandSave, read " << map_parameters.high_freq_kmers.size() << " high frequency kmers." << std::endl;
+    }
+
 
     if (keep_low_align_pct_identity) {
         align_parameters.min_identity = 0; // now unused


### PR DESCRIPTION
Robust winnowing reduces the number of minimizers sampled from repetitive sequences. It also avoids little spikes in the minimizers' distribution.

![image](https://user-images.githubusercontent.com/62253982/117731925-389c4e80-b1ef-11eb-9f86-90e9fdaf22c7.png)
![image](https://user-images.githubusercontent.com/62253982/117731927-3afea880-b1ef-11eb-8a73-f24eea7ccad3.png)


![image](https://user-images.githubusercontent.com/62253982/117731960-47830100-b1ef-11eb-90f9-bd1233f224a4.png)
![image](https://user-images.githubusercontent.com/62253982/117731968-49e55b00-b1ef-11eb-887e-c5685986d54d.png)


That's not clear if this gives a real advantage in mappings boundaries determination: some estimates are a little better, others a little worse.