### PR TITLE
downsample less to get more and better mappings

### DIFF
--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -983,7 +983,7 @@ void write_merged_alignment(
 
         auto distance_close_big_enough_indel = [](const uint32_t indel_len, auto q, const std::vector<char>& erodev) {
             const uint32_t min_indel_len_to_find = indel_len / 2 + 1;
-            const uint16_t max_dist_to_look_at = std::min(indel_len * 10, (uint32_t)4096);
+            const uint16_t max_dist_to_look_at = std::min(indel_len * 16, (uint32_t)4096);
 
             auto qq = q;
             uint32_t size_close_indel = 0;

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -329,7 +329,7 @@ void parse_args(int argc,
                     map_parameters.percentageIdentity,
                     map_parameters.segLength,
                     map_parameters.referenceSize);
-            map_parameters.windowSize = std::min(256, map_parameters.windowSize);
+            map_parameters.windowSize = std::min(64, map_parameters.windowSize);
         }
     }
 


### PR DESCRIPTION
This PR sets the maximum size of the subsampling window to 64. It usually leads to more mappings and better regions' boundaries, while still decent memory and runtime.