### PR TITLE
Remove the CIGAR management in wflambda

### DIFF
--- a/src/common/wflign/deps/wflambda/wflambda/benchmark/benchmark_gap_affine.cpp
+++ b/src/common/wflign/deps/wflambda/wflambda/benchmark/benchmark_gap_affine.cpp
@@ -119,9 +119,9 @@ void benchmark_gap_affine_wavefront(
       align_input->text_length);
   timer_stop(&align_input->timer);
   // Debug alignment
-  if (align_input->debug_flags) {
-    benchmark_check_alignment(align_input,&affine_wavefronts->edit_cigar);
-  }
+//  if (align_input->debug_flags) {
+//    benchmark_check_alignment(align_input,&affine_wavefronts->edit_cigar);
+//  }
   // Free
   affine_wavefronts_delete(affine_wavefronts);
 }

--- a/src/common/wflign/deps/wflambda/wflambda/gap_affine/affine_wavefront.cpp
+++ b/src/common/wflign/deps/wflambda/wflambda/gap_affine/affine_wavefront.cpp
@@ -103,7 +103,7 @@ affine_wavefronts_t* affine_wavefronts_new(
   affine_wavefronts_allocate_wavefront_components(affine_wavefronts);
   affine_wavefronts_allocate_wavefront_null(affine_wavefronts);
   // CIGAR
-  edit_cigar_allocate(&affine_wavefronts->edit_cigar,pattern_length,text_length,mm_allocator);
+  //edit_cigar_allocate(&affine_wavefronts->edit_cigar,pattern_length,text_length,mm_allocator);
   // STATS
   affine_wavefronts->wavefronts_stats = NULL;
   // DEBUG
@@ -153,7 +153,7 @@ void affine_wavefronts_clear(
     }
   }
   // Clear CIGAR
-  edit_cigar_clear(&affine_wavefronts->edit_cigar);
+  //edit_cigar_clear(&affine_wavefronts->edit_cigar);
   // Clear bulk memory
   affine_wavefronts->wavefronts_current = affine_wavefronts->wavefronts_mem;
 }
@@ -171,7 +171,7 @@ void affine_wavefronts_delete(
   // Free bulk memory
   mm_allocator_free(mm_allocator,affine_wavefronts->wavefronts_mem);
   // CIGAR
-  edit_cigar_free(&affine_wavefronts->edit_cigar,mm_allocator);
+  //edit_cigar_free(&affine_wavefronts->edit_cigar,mm_allocator);
   // DEBUG
 #ifdef AFFINE_LAMBDA_WAVEFRONT_DEBUG
   affine_table_free(&affine_wavefronts->gap_affine_table,mm_allocator);

--- a/src/common/wflign/deps/wflambda/wflambda/gap_affine/affine_wavefront.hpp
+++ b/src/common/wflign/deps/wflambda/wflambda/gap_affine/affine_wavefront.hpp
@@ -120,7 +120,7 @@ typedef struct {
   // Penalties
   affine_wavefronts_penalties_t penalties;     // Penalties parameters
   // CIGAR
-  edit_cigar_t edit_cigar;                     // Alignment CIGAR
+  //edit_cigar_t edit_cigar;                     // Alignment CIGAR
   // MM
   mm_allocator_t* mm_allocator;                // MM-Allocator
   affine_wavefront_t* wavefronts_mem;          // MM-Slab for affine_wavefront_t (base)

--- a/src/common/wflign/deps/wflambda/wflambda/gap_affine/affine_wavefront_backtrace.cpp
+++ b/src/common/wflign/deps/wflambda/wflambda/gap_affine/affine_wavefront_backtrace.cpp
@@ -234,8 +234,8 @@ void affine_wavefronts_backtrace_matches__check(
     const int k,
     awf_offset_t offset,
     const bool valid_location,
-    const int num_matches,
-    edit_cigar_t* const edit_cigar) {
+    const int num_matches/*,
+    edit_cigar_t* const edit_cigar*/) {
   int i;
   for (i=0;i<num_matches;++i) {
     // run our traceback function on the alignments
@@ -249,7 +249,7 @@ void affine_wavefronts_backtrace_matches__check(
       exit(1);
     }
     // Set Match
-    edit_cigar->operations[(edit_cigar->begin_offset)--] = 'M';
+    //edit_cigar->operations[(edit_cigar->begin_offset)--] = 'M';
     // Update state
     --offset;
   }
@@ -277,7 +277,7 @@ void affine_wavefronts_backtrace(
   // Parameters
   const affine_penalties_t* const wavefront_penalties =
       &(affine_wavefronts->penalties.wavefront_penalties);
-  edit_cigar_t* const cigar = &affine_wavefronts->edit_cigar;
+  //edit_cigar_t* const cigar = &affine_wavefronts->edit_cigar;
   const int alignment_k = AFFINE_LAMBDA_WAVEFRONT_DIAGONAL(text_length,pattern_length);
   // Compute starting location
   int score = alignment_score;
@@ -290,12 +290,12 @@ void affine_wavefronts_backtrace(
   int h = AFFINE_LAMBDA_WAVEFRONT_H(k,offset);
   while (v > 0 && h > 0 && score > 0) {
     // Check location
-    if (!valid_location) {
-      valid_location = affine_wavefronts_valid_location(k,offset,pattern_length,text_length);
-      if (valid_location) {
-        affine_wavefronts_offset_add_trailing_gap(cigar,k,alignment_k);
-      }
-    }
+//    if (!valid_location) {
+//      valid_location = affine_wavefronts_valid_location(k,offset,pattern_length,text_length);
+//      if (valid_location) {
+//        affine_wavefronts_offset_add_trailing_gap(cigar,k,alignment_k);
+//      }
+//    }
     // Compute scores
     const int gap_open_score = score - wavefront_penalties->gap_opening - wavefront_penalties->gap_extension;
     const int gap_extend_score = score - wavefront_penalties->gap_extension;
@@ -320,27 +320,27 @@ void affine_wavefronts_backtrace(
       const int num_matches = offset - max_all;
       affine_wavefronts_backtrace_matches__check(
           affine_wavefronts,
-          lambda,k,offset,valid_location,num_matches,cigar);
+          lambda,k,offset,valid_location,num_matches/*,cigar*/);
       offset = max_all;
     }
     // Traceback Operation
     if (max_all == del_ext) {
       // Add Deletion
-      if (valid_location) cigar->operations[(cigar->begin_offset)--] = 'D';
+      //if (valid_location) cigar->operations[(cigar->begin_offset)--] = 'D';
       // Update state
       score = gap_extend_score;
       ++k;
       backtrace_type = backtrace_wavefront_D;
     } else if (max_all == del_open) {
       // Add Deletion
-      if (valid_location) cigar->operations[(cigar->begin_offset)--] = 'D';
+      //if (valid_location) cigar->operations[(cigar->begin_offset)--] = 'D';
       // Update state
       score = gap_open_score;
       ++k;
       backtrace_type = backtrace_wavefront_M;
     } else if (max_all == ins_ext) {
       // Add Insertion
-      if (valid_location) cigar->operations[(cigar->begin_offset)--] = 'I';
+      //if (valid_location) cigar->operations[(cigar->begin_offset)--] = 'I';
       // Update state
       score = gap_extend_score;
       --k;
@@ -348,7 +348,7 @@ void affine_wavefronts_backtrace(
       backtrace_type = backtrace_wavefront_I;
     } else if (max_all == ins_open) {
       // Add Insertion
-      if (valid_location) cigar->operations[(cigar->begin_offset)--] = 'I';
+      //if (valid_location) cigar->operations[(cigar->begin_offset)--] = 'I';
       // Update state
       score = gap_open_score;
       --k;
@@ -356,7 +356,7 @@ void affine_wavefronts_backtrace(
       backtrace_type = backtrace_wavefront_M;
     } else if (max_all == misms) {
       // Add Mismatch
-      if (valid_location) cigar->operations[(cigar->begin_offset)--] = 'X';
+      //if (valid_location) cigar->operations[(cigar->begin_offset)--] = 'X';
       // Update state
       score = mismatch_score;
       --offset;
@@ -373,13 +373,13 @@ void affine_wavefronts_backtrace(
     // Account for last stroke of matches
     affine_wavefronts_backtrace_matches__check(
         affine_wavefronts,
-        lambda,k,offset,valid_location,offset,cigar);
-  } else {
+        lambda,k,offset,valid_location,offset/*,cigar*/);
+  } /*else {
     // Account for last stroke of insertion/deletion
     while (v > 0) {cigar->operations[(cigar->begin_offset)--] = 'D'; --v;};
     while (h > 0) {cigar->operations[(cigar->begin_offset)--] = 'I'; --h;};
-  }
-  ++(cigar->begin_offset); // Set CIGAR length
+  }*/
+  //++(cigar->begin_offset); // Set CIGAR length
   // STATS
   WAVEFRONT_STATS_TIMER_STOP(affine_wavefronts,wf_time_backtrace);
 }

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -128,7 +128,7 @@ void wflign_affine_wavefront(
                         wfa_mm_allocator,
                         &wfa_affine_penalties,
                         *aln);
-                //std::cerr << aln->j << "\t" << aln->i << "\t" << aln->score << "\t" << aligned << std::endl;
+                //std::cerr << v << "\t" << h << "\t" << aln->score << "\t" << aligned << std::endl;
                 ++num_alignments;
                 if (aligned) {
                     alignments[k] = aln;

--- a/src/common/wflign/src/wflign_wfa.cpp
+++ b/src/common/wflign/src/wflign_wfa.cpp
@@ -128,7 +128,7 @@ void wflign_affine_wavefront(
                         wfa_mm_allocator,
                         &wfa_affine_penalties,
                         *aln);
-                //std::cerr << v << "\t" << h << "\t" << aln->score << "\t" << aligned << std::endl;
+                //std::cerr << aln->j << "\t" << aln->i << "\t" << aln->score << "\t" << aligned << std::endl;
                 ++num_alignments;
                 if (aligned) {
                     alignments[k] = aln;


### PR DESCRIPTION
This allows gaining a bit of time/memory during alignments for free. Also, it solves the https://github.com/pangenome/pggb/issues/107 issue.