### PR TITLE
directional rkhm sketching

### DIFF
--- a/src/common/wflign/src/rkmh.cpp
+++ b/src/common/wflign/src/rkmh.cpp
@@ -49,12 +49,8 @@ inline void calc_hashes_(const char *seq, const uint64_t &len,
     char fhash[16];
     for (int i = 0; i < numhashes; ++i) {
         if (canonical(seq + i, k)) {
-            reverse_complement(seq + i, reverse, k);
             MurmurHash3_x64_128(seq + i, k, 42, &fhash);
-            MurmurHash3_x64_128(reverse, k, 42, &rhash);
-            hash_t tmp_fwd = *((hash_t*)fhash);
-            hash_t tmp_rev = *((hash_t*)rhash);
-            hashes[i] = (tmp_fwd < tmp_rev ? tmp_fwd : tmp_rev);
+            hashes[i] = *((hash_t*)fhash);
             //std::cerr << "hashes[" << i << "] = " << hashes[i] << std::endl;
         } else {
             hashes[i] = std::numeric_limits<hash_t>::max();


### PR DESCRIPTION
This respects the orientation of the sequences when comparing their kmers.

By calculating (for each chromosome in the mini-HPRC dataset) the difference between `master` and `directional_sketching` for False Negative (FN), False Positive (FP), and True Positive (TP), we obtain that the branch is slightly (slightly) better on average.

![image](https://user-images.githubusercontent.com/62253982/146642677-f19b89fc-8c4e-4b25-9524-822f7007f509.png)
![image](https://user-images.githubusercontent.com/62253982/146642680-a8842364-1fbf-42da-8ca4-538543d3ba64.png)
