### PR TITLE
world minimizers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ include
 \#*
 .\#*
 src/common/WFA/bin/
+src/wfmash_git_version.hpp
 
 test/

--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -344,16 +344,12 @@ namespace skch {
                     hashBwd = CommonFunc::getHash(seqRev + len - i - kmerSize, kmerSize);
                 else  //proteins
                     hashBwd = std::numeric_limits<hash_t>::max();   //Pick a dummy high value so that it is ignored later
-
-                //Consider non-symmetric kmers only
-                if (hashBwd != hashFwd) {
-                    //Take minimum value of kmer and its reverse complement
-                    hash_t currentKmer = std::min(hashFwd, hashBwd);
-
-                    if (currentKmer % samplingFactor == 0) {
-
-                        auto currentStrand = hashFwd < hashBwd ? strnd::FWD : strnd::REV;
-                        minimizerIndex.push_back(MinimizerInfo{currentKmer, seqCounter, i, currentStrand});
+                if (hashBwd != hashFwd) { // consider non-symmetric kmers only
+                    if (hashFwd % samplingFactor == 0) {
+                        minimizerIndex.push_back(MinimizerInfo{hashFwd, seqCounter, i, strnd::FWD});
+                    }
+                    if (hashBwd % samplingFactor == 0) {
+                        minimizerIndex.push_back(MinimizerInfo{hashBwd, seqCounter, i, strnd::REV});
                     }
                 }
             }

--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -11,6 +11,7 @@
 #include <deque>
 #include <cmath>
 #include <fstream>
+#include <limits>
 
 //Own includes
 #include "map/include/map_parameters.hpp"
@@ -332,6 +333,9 @@ namespace skch {
             //Compute reverse complement of seq
             char *seqRev = new char[len];
 
+            // get our sampling fraction
+            hash_t samplingBound = std::numeric_limits<hash_t>::max() / samplingFactor;
+
             if (alphabetSize == 4) //not protein
                 CommonFunc::reverseComplement(seq, seqRev, len);
 
@@ -345,10 +349,10 @@ namespace skch {
                 else  //proteins
                     hashBwd = std::numeric_limits<hash_t>::max();   //Pick a dummy high value so that it is ignored later
                 if (hashBwd != hashFwd) { // consider non-symmetric kmers only
-                    if (hashFwd % samplingFactor == 0) {
+                    if (hashFwd < samplingBound) {
                         minimizerIndex.push_back(MinimizerInfo{hashFwd, seqCounter, i, strnd::FWD});
                     }
-                    if (hashBwd % samplingFactor == 0) {
+                    if (hashBwd < samplingBound) {
                         minimizerIndex.push_back(MinimizerInfo{hashBwd, seqCounter, i, strnd::REV});
                     }
                 }

--- a/src/map/include/commonFunc.hpp
+++ b/src/map/include/commonFunc.hpp
@@ -311,6 +311,56 @@ namespace skch {
         }
 
         /**
+         * @brief       compute winnowed minimizers from a given sequence and add to the index
+         * @param[out]  minimizerIndex  minimizer table storing minimizers and their position as we compute them
+         * @param[in]   seq             pointer to input sequence
+         * @param[in]   len             length of input sequence
+         * @param[in]   kmerSize
+         * @param[in]   samplingFactor
+         * @param[in]   seqCounter      current sequence number, used while saving the position of minimizer
+         */
+        template<typename T>
+        inline void addWorldMinimizers(std::vector<T> &minimizerIndex,
+                                       char *seq, offset_t len,
+                                       int kmerSize,
+                                       int samplingFactor,
+                                       int alphabetSize,
+                                       seqno_t seqCounter) {
+
+            makeUpperCaseAndValidDNA(seq, len);
+
+            //Compute reverse complement of seq
+            char *seqRev = new char[len];
+
+            if (alphabetSize == 4) //not protein
+                CommonFunc::reverseComplement(seq, seqRev, len);
+
+            for (offset_t i = 0; i < len - kmerSize + 1; i++) {
+                //Hash kmers
+                hash_t hashFwd = CommonFunc::getHash(seq + i, kmerSize);
+                hash_t hashBwd;
+
+                if (alphabetSize == 4)
+                    hashBwd = CommonFunc::getHash(seqRev + len - i - kmerSize, kmerSize);
+                else  //proteins
+                    hashBwd = std::numeric_limits<hash_t>::max();   //Pick a dummy high value so that it is ignored later
+
+                //Consider non-symmetric kmers only
+                if (hashBwd != hashFwd) {
+                    //Take minimum value of kmer and its reverse complement
+                    hash_t currentKmer = std::min(hashFwd, hashBwd);
+
+                    if (currentKmer % samplingFactor == 0) {
+
+                        auto currentStrand = hashFwd < hashBwd ? strnd::FWD : strnd::REV;
+                        minimizerIndex.push_back(MinimizerInfo{currentKmer, seqCounter, i, currentStrand});
+                    }
+                }
+            }
+            delete[] seqRev;
+        }
+
+        /**
          * @brief       compute winnowed minimizers from a given sequence and add to the index using spaced seeds
          * @param[out]  minimizerIndex  minimizer table storing minimizers and their position as we compute them
          * @param[in]   seq             pointer to input sequence

--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -497,7 +497,11 @@ namespace skch
           ///1. Compute the minimizers
 
           if (param.spaced_seeds.empty()) {
-            CommonFunc::addMinimizers(Q.minimizerTableQuery, Q.seq, Q.len, param.kmerSize, param.windowSize, param.alphabetSize, Q.seqCounter);//, param.high_freq_kmers);
+              if (param.world_minimizers) {
+                  CommonFunc::addWorldMinimizers(Q.minimizerTableQuery, Q.seq, Q.len, param.kmerSize, param.windowSize, param.alphabetSize, Q.seqCounter);
+              } else {
+                  CommonFunc::addMinimizers(Q.minimizerTableQuery, Q.seq, Q.len, param.kmerSize, param.windowSize, param.alphabetSize, Q.seqCounter);
+              }
           } else {
             CommonFunc::addSpacedSeedMinimizers(Q.minimizerTableQuery, Q.seq, Q.len, param.kmerSize, param.windowSize, param.alphabetSize, Q.seqCounter, param.spaced_seeds);
           }

--- a/src/map/include/map_parameters.hpp
+++ b/src/map/include/map_parameters.hpp
@@ -54,6 +54,7 @@ struct Parameters
     ales_params spaced_seed_params;                   //
     double spaced_seed_sensitivity;                   //
     std::vector<ales::spaced_seed> spaced_seeds;      //
+    bool world_minimizers;
 
     //std::unordered_set<std::string> high_freq_kmers;  //
 };

--- a/src/map/include/winSketch.hpp
+++ b/src/map/include/winSketch.hpp
@@ -192,7 +192,11 @@ namespace skch
 
         //Compute minimizers in reference sequence
         if (param.spaced_seeds.empty()) {
-          skch::CommonFunc::addMinimizers(*thread_output, &(input->seq[0u]), input->len, param.kmerSize, param.windowSize, param.alphabetSize, input->seqCounter);//, param.high_freq_kmers);
+          if (param.world_minimizers) {
+            skch::CommonFunc::addWorldMinimizers(*thread_output, &(input->seq[0u]), input->len, param.kmerSize, param.windowSize, param.alphabetSize, input->seqCounter);
+          } else {
+            skch::CommonFunc::addMinimizers(*thread_output, &(input->seq[0u]), input->len, param.kmerSize, param.windowSize, param.alphabetSize, input->seqCounter);
+          }
         } else {
           skch::CommonFunc::addSpacedSeedMinimizers(*thread_output, &(input->seq[0u]), input->len, param.kmerSize, param.windowSize, param.alphabetSize, input->seqCounter, param.spaced_seeds);
         }

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -74,6 +74,7 @@ void parse_args(int argc,
     args::Flag no_merge(parser, "no-merge", "don't merge consecutive segment-level mappings", {'M', "no-merge"});
 
     args::ValueFlag<int64_t> window_size(parser, "N", "window size for sketching. If 0, it computes the best window size automatically [default: 0 (automatic)]", {'w', "window-size"});
+    args::Flag world_minimizers(parser, "", "Use world minimizers (modimizers) rather than window minimizers [default: use window minimizers]", {'U', "world-minimizers"});
 
     //args::ValueFlag<std::string> path_high_frequency_kmers(parser, "FILE", " input file containing list of high frequency kmers", {'H', "high-freq-kmers"});
 
@@ -473,6 +474,12 @@ void parse_args(int argc,
             // Avoid too big values to improve the accuracy
             map_parameters.windowSize = std::min((int64_t)256, windowSize);
         }
+    }
+
+    if (world_minimizers) {
+        map_parameters.world_minimizers = true;
+    } else {
+        map_parameters.world_minimizers = false;
     }
 
     if (approx_mapping) {

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -74,7 +74,7 @@ void parse_args(int argc,
     args::Flag no_merge(parser, "no-merge", "don't merge consecutive segment-level mappings", {'M', "no-merge"});
 
     args::ValueFlag<int64_t> window_size(parser, "N", "window size for sketching. If 0, it computes the best window size automatically [default: 0 (automatic)]", {'w', "window-size"});
-    args::Flag world_minimizers(parser, "", "Use world minimizers (modimizers) rather than window minimizers [default: use window minimizers]", {'U', "world-minimizers"});
+    args::Flag window_minimizers(parser, "", "Use window minimizers rather than world minimizers", {'U', "window-minimizers"});
 
     //args::ValueFlag<std::string> path_high_frequency_kmers(parser, "FILE", " input file containing list of high frequency kmers", {'H', "high-freq-kmers"});
 
@@ -479,10 +479,10 @@ void parse_args(int argc,
         }
     }
 
-    if (world_minimizers) {
-        map_parameters.world_minimizers = true;
-    } else {
+    if (window_minimizers) {
         map_parameters.world_minimizers = false;
+    } else {
+        map_parameters.world_minimizers = true;
     }
 
     if (approx_mapping) {

--- a/src/yeet/include/parse_args.hpp
+++ b/src/yeet/include/parse_args.hpp
@@ -471,8 +471,11 @@ void parse_args(int argc,
                     map_parameters.segLength,
                     map_parameters.referenceSize);
 
+            // Avoid tiny windows to improve runtime
+            map_parameters.windowSize = std::max((int64_t)map_parameters.kmerSize*2, windowSize);
+
             // Avoid too big values to improve the accuracy
-            map_parameters.windowSize = std::min((int64_t)256, windowSize);
+            map_parameters.windowSize = std::min((int64_t)256, map_parameters.windowSize);
         }
     }
 


### PR DESCRIPTION
Use a predefined subset of all kmers rather than a window-based subset.

This is somewhat faster for mapping. It may violate some assumptions in other parts of the system. The alignments are similar.