### PR TITLE
always apply the plane sweep, even when we do not split

### DIFF
--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -429,6 +429,11 @@ namespace skch
             } while (output->readMappings.size() < mapping_count && ++merge_iter < 2);
             // remove short chains that didn't exceed block length
             filterShortMappings(output->readMappings, param.block_length);
+        } else {
+            // filter the merged mappings using plane sweep
+            if (param.filterMode == filter::MAP || param.filterMode == filter::ONETOONE) {
+                skch::Filter::query::filterMappings(output->readMappings, n_mappings);
+            }
         }
 
         // remove self-mode don't-maps


### PR DESCRIPTION
v0.8.0 has a bug that results in contigs shorter than the block length being mapped without the plane sweep filter. We emit mappings  for all candidates, which is incorrect behavior.