### PR TITLE
`cmake` optimizations, and remove `-mcx16` and `-march=native` by default

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Init and update submodules
         run: git submodule update --init --recursive
       - name: Build wfmash
-        run: sed -i 's/CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -mcx16 -march=native -g/CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -mcx16 -march=native -g -fsanitize=address/g' CMakeLists.txt && sed -i 's/CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -mcx16 -march=native -g/CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -mcx16 -march=native -g -fsanitize=address/g' CMakeLists.txt && cmake -H. -Bbuild && cmake --build build -- -j 2
+        run: cmake -H. -Bbuild -D CMAKE_BUILD_TYPE=Debug && cmake --build build -- -j 2
       - name: Test with a subset of the LPA dataset (PAF output)
         run: ASAN_OPTIONS=detect_leaks=1:symbolize=1 LSAN_OPTIONS=verbosity=0:log_threads=1 build/bin/wfmash data/LPA.subset.fa.gz data/LPA.subset.fa.gz -X -n 10 -T wflign_info. -u ./ > LPA.subset.paf && head LPA.subset.paf
       - name: Test with a subset of the LPA dataset (SAM output)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)  # Make sure no compiler-specific features are use
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_BUILD_TYPE Release)
 
-# set(EXTRA_FLAGS "-Ofast -march=native ")
+# set(EXTRA_FLAGS "-Ofast -mcx16 -march=native ")
 
 if (${CMAKE_BUILD_TYPE} MATCHES "Release")
     if (EXTRA_FLAGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,20 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)  # Falling back to different standard it not allowed.
 set(CMAKE_CXX_EXTENSIONS OFF)  # Make sure no compiler-specific features are used.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_BUILD_TYPE Release)
+
+#set(CMAKE_BUILD_TYPE Release)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+            "Choose the type of build, options are: Release Debug." FORCE)
+endif()
+
+IF(CMAKE_BUILD_TYPE MATCHES Debug)
+    message("Debug build.")
+ELSEIF(CMAKE_BUILD_TYPE MATCHES Release)
+    message("Release build.")
+ELSE()
+    message("Some other build type.")
+ENDIF()
 
 # set(EXTRA_FLAGS "-Ofast -mcx16 -march=native ")
 
@@ -23,8 +36,8 @@ endif ()
 
 if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
     # Debug use the defaults - so commenting out:
-    # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g -fsanitize=address")
-    # set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g -fsanitize=address")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g -fsanitize=address")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g -fsanitize=address")
 endif ()
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,22 @@ set(CMAKE_CXX_EXTENSIONS OFF)  # Make sure no compiler-specific features are use
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_BUILD_TYPE Release)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -mcx16 -march=native -g")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -mcx16 -march=native -g")
-#set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -mcx16  -march=native -g -fsanitize=address")
-#set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -mcx16  -march=native -g -fsanitize=address")
+# set(EXTRA_FLAGS "-Ofast -march=native ")
+
+if (${CMAKE_BUILD_TYPE} MATCHES "Release")
+    if (EXTRA_FLAGS)
+        set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG") # reset CXX_FLAGS to replace -O3 with -Ofast
+    endif (EXTRA_FLAGS)
+    # Use all standard-compliant optimizations - always add these:
+    set (CMAKE_C_FLAGS "${OpenMP_C_FLAGS} ${PIC_FLAG} ${EXTRA_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${OpenMP_CXX_FLAGS} ${PIC_FLAG} ${EXTRA_FLAGS}")
+endif ()
+
+if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
+    # Debug use the defaults - so commenting out:
+    # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g -fsanitize=address")
+    # set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g -fsanitize=address")
+endif ()
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/src/common/wflign/CMakeLists.txt
+++ b/src/common/wflign/CMakeLists.txt
@@ -8,7 +8,20 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)  # Falling back to different standard it not allowed.
 set(CMAKE_CXX_EXTENSIONS OFF)  # Make sure no compiler-specific features are used.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_BUILD_TYPE Release)
+
+#set(CMAKE_BUILD_TYPE Release)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+            "Choose the type of build, options are: Release Debug." FORCE)
+endif()
+
+IF(CMAKE_BUILD_TYPE MATCHES Debug)
+    message("Debug build.")
+ELSEIF(CMAKE_BUILD_TYPE MATCHES Release)
+    message("Release build.")
+ELSE()
+    message("Some other build type.")
+ENDIF()
 
 # set(EXTRA_FLAGS "-Ofast -mcx16 -march=native ")
 

--- a/src/common/wflign/CMakeLists.txt
+++ b/src/common/wflign/CMakeLists.txt
@@ -10,10 +10,22 @@ set(CMAKE_CXX_EXTENSIONS OFF)  # Make sure no compiler-specific features are use
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_BUILD_TYPE Release)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -mcx16 -march=native -g")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -mcx16 -march=native -g")
-#set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -mcx16 -march=native -g -fsanitize=address")
-#set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -mcx16 -march=native -g -fsanitize=address")
+# set(EXTRA_FLAGS "-Ofast -mcx16 -march=native ")
+
+if (${CMAKE_BUILD_TYPE} MATCHES "Release")
+    if (EXTRA_FLAGS)
+        set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG") # reset CXX_FLAGS to replace -O3 with -Ofast
+    endif (EXTRA_FLAGS)
+    # Use all standard-compliant optimizations - always add these:
+    set (CMAKE_C_FLAGS "${OpenMP_C_FLAGS} ${PIC_FLAG} ${EXTRA_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${OpenMP_CXX_FLAGS} ${PIC_FLAG} ${EXTRA_FLAGS}")
+endif ()
+
+if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
+    # Debug use the defaults - so commenting out:
+    # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g -fsanitize=address")
+    # set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g -fsanitize=address")
+endif ()
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/src/common/wflign/deps/WFAv2/CMakeLists.txt
+++ b/src/common/wflign/deps/WFAv2/CMakeLists.txt
@@ -8,6 +8,20 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)  # Falling back to different standard it not allowed.
 set(CMAKE_CXX_EXTENSIONS OFF)  # Make sure no compiler-specific features are used.
 
+#set(CMAKE_BUILD_TYPE Release)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING
+            "Choose the type of build, options are: Release Debug." FORCE)
+endif()
+
+IF(CMAKE_BUILD_TYPE MATCHES Debug)
+    message("Debug build.")
+ELSEIF(CMAKE_BUILD_TYPE MATCHES Release)
+    message("Release build.")
+ELSE()
+    message("Some other build type.")
+ENDIF()
+
 # set(EXTRA_FLAGS "-Ofast -mcx16 -march=native ")
 
 if (${CMAKE_BUILD_TYPE} MATCHES "Release")

--- a/src/common/wflign/deps/WFAv2/CMakeLists.txt
+++ b/src/common/wflign/deps/WFAv2/CMakeLists.txt
@@ -8,8 +8,22 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)  # Falling back to different standard it not allowed.
 set(CMAKE_CXX_EXTENSIONS OFF)  # Make sure no compiler-specific features are used.
 
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -mcx16 -march=native -g -Wno-pointer-arith -D__STDC_FORMAT_MACROS")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -mcx16 -march=native -g -Wno-pointer-arith -D__STDC_FORMAT_MACROS")
+# set(EXTRA_FLAGS "-Ofast -mcx16 -march=native ")
+
+if (${CMAKE_BUILD_TYPE} MATCHES "Release")
+    if (EXTRA_FLAGS)
+        set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG") # reset CXX_FLAGS to replace -O3 with -Ofast
+    endif (EXTRA_FLAGS)
+    # Use all standard-compliant optimizations - always add these:
+    set (CMAKE_C_FLAGS "${OpenMP_C_FLAGS} ${PIC_FLAG} ${EXTRA_FLAGS} -Wno-pointer-arith -D__STDC_FORMAT_MACROS")
+    set (CMAKE_CXX_FLAGS "${OpenMP_CXX_FLAGS} ${PIC_FLAG} ${EXTRA_FLAGS} -Wno-pointer-arith -D__STDC_FORMAT_MACROS")
+endif ()
+
+if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
+    # Debug use the defaults - so commenting out:
+    # set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g -fsanitize=address")
+    # set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g -fsanitize=address")
+endif ()
 
 # Build wfa as static library by default
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build all libraries as shared")


### PR DESCRIPTION
This should fix #125, #126, and #127.