### PR TITLE
Avoid overflow on big plant chromosomes.

### DIFF
--- a/src/map/include/computeMap.hpp
+++ b/src/map/include/computeMap.hpp
@@ -775,7 +775,9 @@ namespace skch
           auto prev_beg_iter = mi_L2iter.sw_beg;
           auto prev_end_iter = mi_L2iter.sw_end;
 
-          int beginOptimalPos, lastOptimalPos;
+          // int64_t prevents overflow when these two variables are averaged
+          // (then summed) before being assigned to an int32_t variable
+          int64_t beginOptimalPos, lastOptimalPos;
 
           while ( std::distance(mi_L2iter.sw_end, lastSuperWindowRangeEnd) >= 0)
           {


### PR DESCRIPTION
 This was leading to wrong mappings with start/end coordinates equal to 0 (visible as vertical lines in the following pafplot), extremely hard to align with our WFA-based implementation.

![wfmash-i2sz7p](https://user-images.githubusercontent.com/62253982/164910464-9df845e8-2074-44e2-8035-202418565fb3.png)

Avoiding the overflow, we get the correct mappings:

![approx paf](https://user-images.githubusercontent.com/62253982/164910506-cd42c004-cc3a-47cb-ad6e-9050dd1a3a07.png)
