### PR TITLE
treat reference segments independently in filtering

### DIFF
--- a/src/map/include/filter.hpp
+++ b/src/map/include/filter.hpp
@@ -52,7 +52,7 @@ namespace skch
           auto x_score = vec[x].qlen() * vec[x].nucIdentity;
           auto y_score = vec[y].qlen() * vec[y].nucIdentity;
 
-          return std::tie(x_score, vec[x].queryStartPos) > std::tie(y_score, vec[y].queryStartPos);
+          return std::tie(x_score, vec[x].queryStartPos, vec[x].refSeqId) > std::tie(y_score, vec[y].queryStartPos, vec[y].refSeqId);
         }
 
         //Greater than comparison by score


### PR DESCRIPTION
We had seen cases of dropout in mappings, and @AndreaGuarracino has traced the issue to a failure of distinguishing mappings of the same score on different reference contigs.

This will resolve https://github.com/pangenome/pggb/issues/195.